### PR TITLE
:sparkles: [FEAT] EmailAuth 엔티티 추가

### DIFF
--- a/src/main/java/kr/co/teacherforboss/domain/EmailAuth.java
+++ b/src/main/java/kr/co/teacherforboss/domain/EmailAuth.java
@@ -1,0 +1,30 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.*;
+import kr.co.teacherforboss.domain.enums.Purpose;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class EmailAuth {
+    @Id
+    @Column(nullable = false, updatable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(10)")
+    private Purpose purpose;
+
+    @Column(nullable = false, length = 50)
+    private String code;
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(1)")
+    private String isChecked;
+}

--- a/src/main/java/kr/co/teacherforboss/domain/EmailAuth.java
+++ b/src/main/java/kr/co/teacherforboss/domain/EmailAuth.java
@@ -1,8 +1,18 @@
 package kr.co.teacherforboss.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import kr.co.teacherforboss.domain.enums.Purpose;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter

--- a/src/main/java/kr/co/teacherforboss/domain/enums/Purpose.java
+++ b/src/main/java/kr/co/teacherforboss/domain/enums/Purpose.java
@@ -1,0 +1,5 @@
+package kr.co.teacherforboss.domain.enums;
+
+public enum Purpose {
+    SIGNUP, ID, PW
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #10 

## 📝 작업 내용

- EmailAuth 엔티티 추가
- Purpose enum 추가


## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

Purpose enum의 경우 임의로 SIGNUP, ID, PW로 두었는데 추후에 기능에 따라 추가하거나 수정하면 될 거 같습니당
