### PR TITLE
✨[FEAT] Member 엔티티 phone 컬럼 추가 & 회원가입 API 로직 수정

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -38,11 +38,13 @@ public enum ErrorStatus implements BaseErrorCode {
     // Member
     MEMBER_NOT_FOUND(BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     NICKNAME_NOT_EXIST(BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
+    MEMBER_DUPLICATE(BAD_REQUEST, "MEMBER4003", "이미 존재하는 이메일입니다."),
 
     // Auth
-    EMAIL_NOT_CHECKED(BAD_REQUEST, "AUTH4001", "이메일을 인증 받지 않았습니다."),
+    MAIL_NOT_CHECKED(BAD_REQUEST, "AUTH4001", "이메일을 인증 받지 않았습니다."),
     PASSWORD_NOT_CORRECT(BAD_REQUEST, "AUTH4002", "비밀번호 입력값과 일치하지 않습니다."),
     INVALID_PASSWORD(BAD_REQUEST, "AUTH4003", "비밀번호 입력 조건을 확인해주세요."),
+    PHONE_NOT_CHECKED(NOT_FOUND, "AUTH4004", "전화번호를 인증 받지 않았습니다."),
 
     // For test
     TEMP_EXCEPTION(BAD_REQUEST, "TEMP4001", "이거는 테스트");

--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -28,11 +28,13 @@ public enum ErrorStatus implements BaseErrorCode {
     // Member
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
+    MEMBER_DUPLICATE(HttpStatus.BAD_REQUEST, "MEMBER4003", "이미 존재하는 이메일입니다."),
 
     // Auth
-    EMAIL_NOT_CHECKED(HttpStatus.BAD_REQUEST, "AUTH4001", "이메일을 인증 받지 않았습니다."),
+    MAIL_NOT_CHECKED(HttpStatus.NOT_FOUND, "AUTH4001", "이메일을 인증 받지 않았습니다."),
     PASSWORD_NOT_CORRECT(HttpStatus.BAD_REQUEST, "AUTH4002", "비밀번호 입력값과 일치하지 않습니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "AUTH4003", "비밀번호 입력 조건을 확인해주세요."),
+    PHONE_NOT_CHECKED(HttpStatus.NOT_FOUND, "AUTH4004", "전화번호를 인증 받지 않았습니다."),
 
     // For test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트");

--- a/src/main/java/kr/co/teacherforboss/apiPayload/exception/handler/MemberHandler.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/exception/handler/MemberHandler.java
@@ -1,0 +1,11 @@
+package kr.co.teacherforboss.apiPayload.exception.handler;
+
+import kr.co.teacherforboss.apiPayload.code.BaseErrorCode;
+import kr.co.teacherforboss.apiPayload.exception.GeneralException;
+
+public class MemberHandler extends GeneralException {
+
+    public MemberHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
@@ -35,6 +35,7 @@ public class AuthConverter {
                 .role(Role.USER)
                 .gender(gender)
                 .birthDate(request.getBirthDate())
+                .phone(request.getPhone())
                 .build();
     }
     

--- a/src/main/java/kr/co/teacherforboss/domain/Member.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Member.java
@@ -61,6 +61,10 @@ public class Member extends BaseEntity {
     @Column(columnDefinition = "VARCHAR(10)")
     private Gender gender;
 
+    @NotNull
+    @Column(length = 50)
+    private String phone;
+
     @Column
     private LocalDate birthDate;
 

--- a/src/main/java/kr/co/teacherforboss/domain/PhoneAuth.java
+++ b/src/main/java/kr/co/teacherforboss/domain/PhoneAuth.java
@@ -19,11 +19,11 @@ import org.hibernate.annotations.ColumnDefault;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class EmailAuth extends BaseEntity {
+public class PhoneAuth extends BaseEntity {
 
     @NotNull
     @Column(length = 50)
-    private String email;
+    private String phone;
 
     @NotNull
     @Enumerated(EnumType.STRING)
@@ -38,8 +38,5 @@ public class EmailAuth extends BaseEntity {
     @Column(columnDefinition = "VARCHAR(1)")
     @ColumnDefault("'F'")
     private String isChecked;
-
-    public void setCode(String code) {
-        this.code = code;
-    }
+    
 }

--- a/src/main/java/kr/co/teacherforboss/repository/EmailAuthRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/EmailAuthRepository.java
@@ -1,9 +1,13 @@
 package kr.co.teacherforboss.repository;
 
 import kr.co.teacherforboss.domain.EmailAuth;
+import kr.co.teacherforboss.domain.enums.Purpose;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
+    boolean existsByEmailAndPurposeAndIsChecked(String email, Purpose purpose, String isChecked);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/EmailAuthRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/EmailAuthRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 
 @Repository
 public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
-    boolean existsByEmailAndPurposeAndIsChecked(String email, Purpose purpose, String isChecked);
+    boolean existsByIdAndEmailAndPurposeAndIsChecked(Long emailAuthId, String email, Purpose purpose, String isChecked);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/EmailAuthRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/EmailAuthRepository.java
@@ -5,8 +5,6 @@ import kr.co.teacherforboss.domain.enums.Purpose;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
 public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
     boolean existsByIdAndEmailAndPurposeAndIsChecked(Long emailAuthId, String email, Purpose purpose, String isChecked);

--- a/src/main/java/kr/co/teacherforboss/repository/MemberRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberRepository.java
@@ -5,8 +5,6 @@ import kr.co.teacherforboss.domain.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmailAndStatus(String email, Status status);

--- a/src/main/java/kr/co/teacherforboss/repository/MemberRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberRepository.java
@@ -1,9 +1,13 @@
 package kr.co.teacherforboss.repository;
 
 import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByEmailAndStatus(String email, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/PhoneAuthRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/PhoneAuthRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface PhoneAuthRepository extends JpaRepository<PhoneAuth, Long> {
-    boolean existsByPhoneAndPurposeAndIsChecked(String phone, Purpose purpose, String isChecked);
+    boolean existsByIdAndPhoneAndPurposeAndIsChecked(Long phoneAuthId, String phone, Purpose purpose, String isChecked);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/PhoneAuthRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/PhoneAuthRepository.java
@@ -4,8 +4,6 @@ import kr.co.teacherforboss.domain.PhoneAuth;
 import kr.co.teacherforboss.domain.enums.Purpose;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface PhoneAuthRepository extends JpaRepository<PhoneAuth, Long> {
     boolean existsByIdAndPhoneAndPurposeAndIsChecked(Long phoneAuthId, String phone, Purpose purpose, String isChecked);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/PhoneAuthRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/PhoneAuthRepository.java
@@ -1,0 +1,11 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.PhoneAuth;
+import kr.co.teacherforboss.domain.enums.Purpose;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PhoneAuthRepository extends JpaRepository<PhoneAuth, Long> {
+    boolean existsByPhoneAndPurposeAndIsChecked(String phone, Purpose purpose, String isChecked);
+}

--- a/src/main/java/kr/co/teacherforboss/service/AuthService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/AuthService/AuthCommandServiceImpl.java
@@ -37,10 +37,14 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     @Override
     @Transactional
     public Member joinMember(AuthRequestDTO.JoinDTO request){
-        if (memberRepository.existsByEmailAndStatus(request.getEmail(), Status.ACTIVE)) throw new MemberHandler(ErrorStatus.MEMBER_DUPLICATE);
-        if (!emailAuthRepository.existsByIdAndEmailAndPurposeAndIsChecked(request.getEmailAuthId(), request.getEmail(), Purpose.of(1), "T")) throw new AuthHandler(ErrorStatus.MAIL_NOT_CHECKED);
-        if (!request.getPassword().equals(request.getRePassword())) throw new AuthHandler(ErrorStatus.PASSWORD_NOT_CORRECT);
-        if (!phoneAuthRepository.existsByIdAndPhoneAndPurposeAndIsChecked(request.getPhoneAuthId(), request.getPhone(), Purpose.of(1), "T")) throw new AuthHandler(ErrorStatus.PHONE_NOT_CHECKED);
+        if (memberRepository.existsByEmailAndStatus(request.getEmail(), Status.ACTIVE))
+            throw new MemberHandler(ErrorStatus.MEMBER_DUPLICATE);
+        if (!emailAuthRepository.existsByIdAndEmailAndPurposeAndIsChecked(request.getEmailAuthId(), request.getEmail(), Purpose.of(1), "T"))
+            throw new AuthHandler(ErrorStatus.MAIL_NOT_CHECKED);
+        if (!request.getPassword().equals(request.getRePassword()))
+            throw new AuthHandler(ErrorStatus.PASSWORD_NOT_CORRECT);
+        if (!phoneAuthRepository.existsByIdAndPhoneAndPurposeAndIsChecked(request.getPhoneAuthId(), request.getPhone(), Purpose.of(1), "T"))
+            throw new AuthHandler(ErrorStatus.PHONE_NOT_CHECKED);
 
         Member newMember = AuthConverter.toMember(request);
         String pwSalt = generateSalt();

--- a/src/main/java/kr/co/teacherforboss/service/AuthService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/AuthService/AuthCommandServiceImpl.java
@@ -6,7 +6,6 @@ import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
 import kr.co.teacherforboss.apiPayload.exception.handler.AuthHandler;
 import kr.co.teacherforboss.apiPayload.exception.handler.MemberHandler;
 import kr.co.teacherforboss.converter.AuthConverter;
-import kr.co.teacherforboss.domain.PhoneAuth;
 import kr.co.teacherforboss.domain.enums.Purpose;
 import kr.co.teacherforboss.domain.enums.Status;
 import kr.co.teacherforboss.repository.PhoneAuthRepository;
@@ -39,9 +38,9 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     @Transactional
     public Member joinMember(AuthRequestDTO.JoinDTO request){
         if (memberRepository.existsByEmailAndStatus(request.getEmail(), Status.ACTIVE)) throw new MemberHandler(ErrorStatus.MEMBER_DUPLICATE);
-        if (emailAuthRepository.existsByEmailAndPurposeAndIsChecked(request.getEmail(), Purpose.of(1), "T")) throw new AuthHandler(ErrorStatus.MAIL_NOT_CHECKED);
+        if (!emailAuthRepository.existsByIdAndEmailAndPurposeAndIsChecked(request.getEmailAuthId(), request.getEmail(), Purpose.of(1), "T")) throw new AuthHandler(ErrorStatus.MAIL_NOT_CHECKED);
         if (!request.getPassword().equals(request.getRePassword())) throw new AuthHandler(ErrorStatus.PASSWORD_NOT_CORRECT);
-        if (phoneAuthRepository.existsByPhoneAndPurposeAndIsChecked(request.getEmail(), Purpose.of(1), "T")) throw new AuthHandler(ErrorStatus.PHONE_NOT_CHECKED);
+        if (!phoneAuthRepository.existsByIdAndPhoneAndPurposeAndIsChecked(request.getPhoneAuthId(), request.getPhone(), Purpose.of(1), "T")) throw new AuthHandler(ErrorStatus.PHONE_NOT_CHECKED);
 
         Member newMember = AuthConverter.toMember(request);
         String pwSalt = generateSalt();

--- a/src/main/java/kr/co/teacherforboss/service/AuthService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/AuthService/AuthCommandServiceImpl.java
@@ -2,7 +2,12 @@ package kr.co.teacherforboss.service.AuthService;
 
 import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
 import kr.co.teacherforboss.apiPayload.exception.handler.AuthHandler;
+import kr.co.teacherforboss.apiPayload.exception.handler.MemberHandler;
 import kr.co.teacherforboss.converter.AuthConverter;
+import kr.co.teacherforboss.domain.PhoneAuth;
+import kr.co.teacherforboss.domain.enums.Purpose;
+import kr.co.teacherforboss.domain.enums.Status;
+import kr.co.teacherforboss.repository.PhoneAuthRepository;
 import kr.co.teacherforboss.web.dto.AuthRequestDTO;
 import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.EmailAuth;
@@ -23,6 +28,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
     private final MemberRepository memberRepository;
     private final EmailAuthRepository emailAuthRepository;
+    private final PhoneAuthRepository phoneAuthRepository;
     private final MailCommandService mailCommandService;
     private final PasswordEncoder passwordEncoder;
 
@@ -30,7 +36,10 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     @Override
     @Transactional
     public Member joinMember(AuthRequestDTO.JoinDTO request){
-        if (!request.getPassword().equals(request.getRePassword())) { throw new AuthHandler(ErrorStatus.PASSWORD_NOT_CORRECT);}
+        if (memberRepository.existsByEmailAndStatus(request.getEmail(), Status.ACTIVE)) throw new MemberHandler(ErrorStatus.MEMBER_DUPLICATE);
+        if (emailAuthRepository.existsByEmailAndPurposeAndIsChecked(request.getEmail(), Purpose.of(1), "T")) throw new AuthHandler(ErrorStatus.MAIL_NOT_CHECKED);
+        if (!request.getPassword().equals(request.getRePassword())) throw new AuthHandler(ErrorStatus.PASSWORD_NOT_CORRECT);
+        if (phoneAuthRepository.existsByPhoneAndPurposeAndIsChecked(request.getEmail(), Purpose.of(1), "T")) throw new AuthHandler(ErrorStatus.PHONE_NOT_CHECKED);
 
         Member newMember = AuthConverter.toMember(request);
         String pwSalt = generateSalt();

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -19,6 +19,10 @@ public class AuthRequestDTO {
         @NotNull
         String email;
 
+        Long emailAuthId;
+
+        Long phoneAuthId;
+
         @NotNull
         @Size(min = 8, max = 20, message = "비밀번호를 8~20자 사이로 입력해주세요.")
         @Pattern(regexp="(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+{}|:<>?~,-]).{8,20}", message = "비밀번호는 숫자, 영어, 특수문자를 포함해서 8 ~ 20자리 이내로 입력해주세요.")
@@ -31,6 +35,7 @@ public class AuthRequestDTO {
         String name;
 
         @NotNull
+        @Pattern(regexp = "^01(?:0|1|[6-9])[.-]?(\\d{3}|\\d{4})[.-]?(\\d{4})$", message = "전화번호는 10 ~ 11 자리의 숫자만 입력 가능합니다.")
         String phone;
 
         Integer gender;
@@ -39,7 +44,7 @@ public class AuthRequestDTO {
     }
     
     @Getter
-    @AllArgsConstructor
+    @Builder
     public static class SendCodeMailDTO {
         @NotNull(message = "email 값이 없습니다.")
         @Email(message = "email 값이 이메일 형식이 아닙니다.")

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.AllArgsConstructor;
 
 import java.time.LocalDate;
 
@@ -63,5 +62,16 @@ public class AuthRequestDTO {
         @NotNull(message = "emailAuthCode 값이 없습니다.")
         @Pattern(regexp = "\\d{5}", message = "인증 코드는 5자리의 숫자로 이루어져 있어야 합니다.")
         String emailAuthCode;
+    }
+
+    @Getter
+    @Builder
+    public static class SendCodePhoneDTO {
+        @NotNull(message = "phone 값이 없습니다.")
+        @Pattern(regexp = "^01(?:0|1|[6-9])[.-]?(\\d{3}|\\d{4})[.-]?(\\d{4})$", message = "전화번호는 10 ~ 11 자리의 숫자만 입력 가능합니다.")
+        String phone;
+
+        @CheckPurpose
+        int purpose;
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -19,9 +19,6 @@ public class AuthRequestDTO {
         @NotNull
         String email;
 
-        @Pattern(regexp="T", message = "이메일을 인증받아야 합니다.")
-        String isChecked;
-
         @NotNull
         @Size(min = 8, max = 20, message = "비밀번호를 8~20자 사이로 입력해주세요.")
         @Pattern(regexp="(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+{}|:<>?~,-]).{8,20}", message = "비밀번호는 숫자, 영어, 특수문자를 포함해서 8 ~ 20자리 이내로 입력해주세요.")
@@ -32,6 +29,9 @@ public class AuthRequestDTO {
 
         @NotNull
         String name;
+
+        @NotNull
+        String phone;
 
         Integer gender;
 

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -18,8 +18,10 @@ public class AuthRequestDTO {
         @NotNull
         String email;
 
+        @NotNull
         Long emailAuthId;
 
+        @NotNull
         Long phoneAuthId;
 
         @NotNull

--- a/src/test/java/kr/co/teacherforboss/service/AuthService/AuthCommandServiceImplTest.java
+++ b/src/test/java/kr/co/teacherforboss/service/AuthService/AuthCommandServiceImplTest.java
@@ -1,12 +1,25 @@
 package kr.co.teacherforboss.service.AuthService;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
+
+import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
+import kr.co.teacherforboss.apiPayload.exception.GeneralException;
+import kr.co.teacherforboss.apiPayload.exception.handler.AuthHandler;
 import kr.co.teacherforboss.domain.EmailAuth;
+import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.PhoneAuth;
+import kr.co.teacherforboss.domain.enums.Gender;
+import kr.co.teacherforboss.domain.enums.LoginType;
 import kr.co.teacherforboss.domain.enums.Purpose;
+import kr.co.teacherforboss.domain.enums.Role;
 import kr.co.teacherforboss.domain.vo.mailVO.CodeMail;
 import kr.co.teacherforboss.domain.vo.mailVO.Mail;
 import kr.co.teacherforboss.repository.EmailAuthRepository;
+import kr.co.teacherforboss.repository.MemberRepository;
+import kr.co.teacherforboss.repository.PhoneAuthRepository;
 import kr.co.teacherforboss.service.MailService.MailCommandService;
 import kr.co.teacherforboss.web.dto.AuthRequestDTO;
 import org.junit.jupiter.api.DisplayName;
@@ -14,28 +27,38 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static reactor.core.publisher.Mono.when;
 
 @ExtendWith(MockitoExtension.class)
 public class AuthCommandServiceImplTest {
 
-    @InjectMocks
+    @InjectMocks @Spy
     private AuthCommandServiceImpl authCommandService;
-
     @Mock
     private MailCommandService mailCommandService;
     @Mock
     private EmailAuthRepository emailAuthRepository;
     @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private PhoneAuthRepository phoneAuthRepository;
+    @Mock
     private CodeMail codeMail;
 
+    /*
+    // TODO: 이메일 인증 테스트
+     */
     @DisplayName("이메일 인증 (성공)")
     @Test
     void saveEmailAuth() {
@@ -75,6 +98,58 @@ public class AuthCommandServiceImplTest {
                 .purpose(Purpose.SIGNUP)
                 .code("12345")
                 .isChecked("F")
+                .build();
+    }
+
+    /*
+    // TODO: 회원 가입 테스트
+     */
+    @DisplayName("회원 가입 (성공) - 비밀번호 검증 제외")
+    @Test
+    void joinMember() {
+        // given
+        Member expected = member();
+        AuthRequestDTO.JoinDTO request = request("백채연", "email@gmail.com", "asdf1234", "asdf1234", 2, "01012341234"); // request로 입력한 Member data
+        doReturn(expected).when(memberRepository)
+                .save(any(Member.class));
+
+        // when
+        Member savedMember = authCommandService.joinMember(request);
+
+        // then
+        assertThat(expected.getEmail()).isEqualTo(savedMember.getEmail());
+        assertThat(expected.getName()).isEqualTo(savedMember.getName());
+
+        // verify
+        verify(memberRepository, times(1)).save(any(Member.class));
+
+    }
+
+    private Member member(){
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return Member.builder()
+                .name("백채연")
+                .email("email@gmail.com")
+                .loginType(LoginType.GENERAL)
+                .role(Role.USER)
+                .birthDate(LocalDate.parse("2000-04-22", formatter))
+                .gender(Gender.FEMALE)
+                .phone("01012341234")
+                .pwSalt("salt")
+                .pwHash("hash")
+                .build();
+    }
+
+    private AuthRequestDTO.JoinDTO request(String name, String email, String pw, String rePw, Integer gender, String phone){
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return AuthRequestDTO.JoinDTO.builder()
+                .name(name)
+                .email(email)
+                .password(pw)
+                .rePassword(rePw)
+                .birthDate(LocalDate.parse("2000-04-22", formatter))
+                .phone(phone)
+                .gender(gender)
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #21 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- PhoneAuth 엔티티 추가
- Member 엔티티 phone 컬럼 추가
- 회원가입 API 로직 수정

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

- member 중복 여부 확인 추가
- EmailAuth isChecked 조건 체크 추가
- PhoneAuth isChecked 조건 체크 추가

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 회원가입 API 테스트 성공 부분의 경우 비밀번호 암호화 관련하여 generateSalt(), generateHash() 메서드를 사용해야하는데요!  Spring의 ReflectionTestUtils를 사용할지 고민했는데, private 메서드 자체를 테스트한다면 테스트 코드와의 결합력이 높아지기도 하고 테스트 코드 사용 비용이 높아지니 최대한 지양하려고 하다.. 우선 객체의 비밀번호(salt, hash)값을 임의로 설정한 후 저장된 후의 이메일, 이름값만 비교해서 return하는 식으로 추가했는데요! 혹시 더 좋은 방법이 있을까요....?!
