### PR TITLE
🐛[FIX] JWT 토큰 파싱 로직 수정 (Bearer 누락)

### DIFF
--- a/src/main/java/kr/co/teacherforboss/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/co/teacherforboss/config/jwt/JwtTokenProvider.java
@@ -35,6 +35,8 @@ public class JwtTokenProvider {
 
     @Value("${jwt.secret}")
     private String secretKey;
+
+    public static final String TOKEN_PREFIX = "Bearer ";
     private static final String KEY_ROLES = "roles";
     protected static final long ACCESS_TOKEN_EXPIRE_TIME = (long) 1000 * 60 * 60 * 24; // 24시간
     protected static final long REFRESH_TOKEN_EXPIRE_TIME = (long) 1000 * 60 * 60 * 24 * 30; // 1달
@@ -111,6 +113,13 @@ public class JwtTokenProvider {
 
     public boolean isAccessTokenDenied(String accessToken) {
         return tokenManager.existBlackListAccessToken(accessToken);
+    }
+
+    public String resolveTokenFromRequest(String token) {
+        if (StringUtils.hasText(token) && token.startsWith(TOKEN_PREFIX)) {
+            return token.substring(TOKEN_PREFIX.length());
+        }
+        return null;
     }
 
     private String getUsername(String token) {

--- a/src/main/java/kr/co/teacherforboss/config/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/co/teacherforboss/config/jwt/filter/JwtAuthenticationFilter.java
@@ -28,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        String token = request.getHeader(TOKEN_HEADER);
+        String token = jwtTokenProvider.resolveTokenFromRequest(request.getHeader(TOKEN_HEADER));
 
         if(StringUtils.hasText(token) && jwtTokenProvider.validateToken(token) && !jwtTokenProvider.isAccessTokenDenied(token)) {
             Authentication auth = jwtTokenProvider.getAuthentication(token);

--- a/src/main/java/kr/co/teacherforboss/web/controller/AuthController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/AuthController.java
@@ -86,8 +86,9 @@ public class AuthController {
     @PostMapping("/logout")
     public ApiResponse<AuthResponseDTO.LogoutResultDTO> logout(@NotNull @RequestHeader("Authorization") String accessToken,
                                                                @ExistPrincipalDetails @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        AuthResponseDTO.LogoutResultDTO logoutResultDTO = authCommandService.logout(accessToken, principalDetails.getEmail());
-        return ApiResponse.onSuccess(AuthConverter.toLogoutResultDTO(logoutResultDTO.getEmail(), accessToken));
+        String token = jwtTokenProvider.resolveTokenFromRequest(accessToken);
+        AuthResponseDTO.LogoutResultDTO logoutResultDTO = authCommandService.logout(token, principalDetails.getEmail());
+        return ApiResponse.onSuccess(AuthConverter.toLogoutResultDTO(logoutResultDTO.getEmail(), token));
     }
 
     @PostMapping("/reissue")


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #48 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- JWT 전달 과정에서 'Bearer ' 문자열 처리
- **Postman에서 테스트 하는 경우, Header에 따로 명시하지 않고 Auth에서 Bearer Token에 AcessToken값 입력해주시면 됩니다!**
![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/113760409/f9f5e2eb-9a62-44a3-b84a-5b76101c32d6)


## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)
- 로그아웃시, Header의 accessToken에 Beaer 문자열이 존재하지 않는 경우 예외처리
- JwtAuthenticationFilter에서 Bearer 문자열 존재 여부 예외처리

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

**사전 정보 저장 (/api/v1/members/survey) API에서 JWT 인증 테스트 완료**
- Auth에 토큰을 입력한 경우 (사용자 인증 성공)
![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/113760409/b3327638-5687-4f97-bf0b-dbdbc340f291)

- Auth에 토큰을 입력하지 않은 경우 (존재하지 않는 사용자 예외처리 응답)
![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/113760409/9d80af75-00ec-421e-a817-08707cea34da)
