### PR TITLE
✨[FEAT] 소셜로그인 API

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -40,6 +40,8 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     NICKNAME_NOT_EXIST(BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
     MEMBER_DUPLICATE(BAD_REQUEST, "MEMBER4003", "이미 존재하는 이메일입니다."),
+    GENERAL_MEMBER_DUPLICATE(BAD_REQUEST, "MEMBER4004", "일반 회원가입을 통해 진행한 이메일 계정입니다."),
+    SOCIAL_MEMBER_INFO_EMPTY(BAD_REQUEST, "MEMBER4005", "소셜 회원가입에 필요한 값이 없습니다."),
 
     // Survey
     SURVEY_DUPLICATE(BAD_REQUEST, "SURVEY4001", "이미 사전정보가 존재합니다."),
@@ -58,6 +60,7 @@ public enum ErrorStatus implements BaseErrorCode {
     TIMEOUT_CODE_MAIL(BAD_REQUEST, "AUTH40011", "이메일 인증 유효시간이 만료되었습니다."),
     INVALID_CODE_PHONE(BAD_REQUEST, "AUTH40012", "휴대폰 인증번호가 틀렸습니다."),
     TIMEOUT_CODE_PHONE(BAD_REQUEST, "AUTH40013", "휴대폰 인증 유효시간이 만료되었습니다."),
+    SOCIAL_TYPE_BAD_REQUEST(BAD_REQUEST, "AUTH40014", "기입한 소셜 로그인 유형과 일치하지 않습니다."),
 
     // For test
     TEMP_EXCEPTION(BAD_REQUEST, "TEMP4001", "이거는 테스트");

--- a/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
@@ -103,7 +103,7 @@ public class AuthConverter {
                 .build();
     }
 
-    public static Member toSocialMember(AuthRequestDTO.SocialLoginDTO request){
+    public static Member toSocialMember(AuthRequestDTO.SocialLoginDTO request, int socialType){
         Gender gender = switch (request.getGender()) {
             case 1 -> Gender.MALE;
             case 2 -> Gender.FEMALE;
@@ -115,7 +115,7 @@ public class AuthConverter {
                 .email(request.getEmail())
                 .role(Role.USER)
                 .gender(gender)
-                .loginType(LoginType.of(request.getSocialType()))
+                .loginType(LoginType.of(socialType))
                 .birthDate(request.getBirthDate())
                 .phone(request.getPhone())
                 .profileImg(request.getProfileImg())

--- a/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
@@ -102,4 +102,22 @@ public class AuthConverter {
                 .createdAt(member.getCreatedAt())
                 .build();
     }
+
+    public static Member toSocialMember(AuthRequestDTO.SocialLoginDTO request){
+        Gender gender = switch (request.getGender()) {
+            case 1 -> Gender.MALE;
+            case 2 -> Gender.FEMALE;
+            default -> Gender.NONE;
+        };
+
+        return Member.builder()
+                .name(request.getName())
+                .email(request.getEmail())
+                .role(Role.USER)
+                .gender(gender)
+                .birthDate(request.getBirthDate())
+                .phone(request.getPhone())
+                .profileImg(request.getProfileImg())
+                .build();
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
@@ -115,6 +115,7 @@ public class AuthConverter {
                 .email(request.getEmail())
                 .role(Role.USER)
                 .gender(gender)
+                .loginType(LoginType.of(request.getSocialType()))
                 .birthDate(request.getBirthDate())
                 .phone(request.getPhone())
                 .profileImg(request.getProfileImg())

--- a/src/main/java/kr/co/teacherforboss/domain/Member.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Member.java
@@ -73,8 +73,4 @@ public class Member extends BaseEntity {
         this.pwHash = pwHash;
     }
 
-    public void setLoginType(int loginType){
-        this.loginType = LoginType.of(loginType);
-    }
-
 }

--- a/src/main/java/kr/co/teacherforboss/domain/Member.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Member.java
@@ -73,4 +73,8 @@ public class Member extends BaseEntity {
         this.pwHash = pwHash;
     }
 
+    public void setLoginType(int loginType){
+        this.loginType = LoginType.of(loginType);
+    }
+
 }

--- a/src/main/java/kr/co/teacherforboss/domain/enums/LoginType.java
+++ b/src/main/java/kr/co/teacherforboss/domain/enums/LoginType.java
@@ -1,5 +1,20 @@
 package kr.co.teacherforboss.domain.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum LoginType {
-    GENERAL, KAKAO, GOOGLE
+    GENERAL(1),
+    KAKAO(2),
+    NAVER(3);
+
+    private final int identifier;
+
+    public static LoginType of(int identifier) {
+        if (identifier == 2) return KAKAO;
+        if (identifier == 3) return NAVER;
+        return GENERAL;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/repository/MemberRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package kr.co.teacherforboss.repository;
 
 import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.enums.LoginType;
 import kr.co.teacherforboss.domain.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -13,4 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmailAndStatus(String email, Status status);
     Optional<Member> findByEmail(String email);
     Member findByPhoneAndStatus(String phone, Status status);
+    boolean existsByEmailAndStatusAndLoginType(String email, Status status, LoginType loginType);
+    Member findByEmailAndStatusAndLoginType(String email, Status status, LoginType loginType);
 }

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandService.java
@@ -18,5 +18,5 @@ public interface AuthCommandService {
     AuthResponseDTO.LogoutResultDTO logout(String accessToken, String email);
     Member findEmail(AuthRequestDTO.FindEmailDTO request);
     Member getMember();
-    Member socialLogin(AuthRequestDTO.SocialLoginDTO request);
+    Member socialLogin(AuthRequestDTO.SocialLoginDTO request, int socialType);
 }

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandService.java
@@ -14,7 +14,7 @@ public interface AuthCommandService {
     boolean checkCodePhone(AuthRequestDTO.CheckCodePhoneDTO request);
     Member findPassword(AuthRequestDTO.FindPasswordDTO request);
     Member login(AuthRequestDTO.LoginDTO request);
-    Member resetPassword(AuthRequestDTO.resetPasswordDTO request);
+    Member resetPassword(AuthRequestDTO.ResetPasswordDTO request);
     AuthResponseDTO.LogoutResultDTO logout(String accessToken, String email);
     Member findEmail(AuthRequestDTO.FindEmailDTO request);
     Member getMember();

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandService.java
@@ -18,4 +18,5 @@ public interface AuthCommandService {
     AuthResponseDTO.LogoutResultDTO logout(String accessToken, String email);
     Member findEmail(AuthRequestDTO.FindEmailDTO request);
     Member getMember();
+    Member socialLogin(AuthRequestDTO.SocialLoginDTO request);
 }

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
@@ -200,15 +200,15 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
     @Override
     @Transactional
-    public Member socialLogin(AuthRequestDTO.SocialLoginDTO request) {
+    public Member socialLogin(AuthRequestDTO.SocialLoginDTO request, int socialType) {
         if (memberRepository.existsByEmailAndStatusAndLoginType(request.getEmail(), Status.ACTIVE, LoginType.GENERAL))
             throw new MemberHandler(ErrorStatus.GENERAL_MEMBER_DUPLICATE);
-        if (memberRepository.existsByEmailAndStatusAndLoginType(request.getEmail(), Status.ACTIVE, LoginType.of(request.getSocialType())))
-            return memberRepository.findByEmailAndStatusAndLoginType(request.getEmail(), Status.ACTIVE, LoginType.of(request.getSocialType()));
+        if (memberRepository.existsByEmailAndStatusAndLoginType(request.getEmail(), Status.ACTIVE, LoginType.of(socialType)))
+            return memberRepository.findByEmailAndStatusAndLoginType(request.getEmail(), Status.ACTIVE, LoginType.of(socialType));
         if (request.getName() == null || request.getPhone() == null)
             throw new MemberHandler(ErrorStatus.SOCIAL_MEMBER_INFO_EMPTY);
 
-        Member newMember = AuthConverter.toSocialMember(request);
+        Member newMember = AuthConverter.toSocialMember(request, socialType);
         passwordUtil.setSocialMemberPassword(newMember);
 
         return memberRepository.save(newMember);

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
@@ -209,7 +209,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
             throw new MemberHandler(ErrorStatus.SOCIAL_MEMBER_INFO_EMPTY);
 
         Member newMember = AuthConverter.toSocialMember(request);
-        passwordUtil.setMemberPassword(newMember, request.getPassword());
+        passwordUtil.setSocialMemberPassword(newMember);
 
         return memberRepository.save(newMember);
     }

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
@@ -186,7 +186,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
   
     @Override
     @Transactional
-    public Member resetPassword(AuthRequestDTO.resetPasswordDTO request) {
+    public Member resetPassword(AuthRequestDTO.ResetPasswordDTO request) {
         Member member = memberRepository.findById(request.getMemberId())
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
@@ -209,7 +209,6 @@ public class AuthCommandServiceImpl implements AuthCommandService {
             throw new MemberHandler(ErrorStatus.SOCIAL_MEMBER_INFO_EMPTY);
 
         Member newMember = AuthConverter.toSocialMember(request);
-        newMember.setLoginType(request.getSocialType());
         passwordUtil.setMemberPassword(newMember, request.getPassword());
 
         return memberRepository.save(newMember);

--- a/src/main/java/kr/co/teacherforboss/util/PasswordUtil.java
+++ b/src/main/java/kr/co/teacherforboss/util/PasswordUtil.java
@@ -42,7 +42,7 @@ public class PasswordUtil {
 
     public void setSocialMemberPassword(Member member){
         String pwSalt = generateSalt();
-        String pwHash = generatePwHash(getRandomPassword(8), pwSalt);
+        String pwHash = generatePwHash(getRandomPassword(20), pwSalt);
         member.setPassword(pwSalt, pwHash);
     }
 

--- a/src/main/java/kr/co/teacherforboss/util/PasswordUtil.java
+++ b/src/main/java/kr/co/teacherforboss/util/PasswordUtil.java
@@ -39,4 +39,31 @@ public class PasswordUtil {
 
         return sb.toString();
     }
+
+    public void setSocialMemberPassword(Member member){
+        String pwSalt = generateSalt();
+        String pwHash = generatePwHash(getRandomPassword(8), pwSalt);
+        member.setPassword(pwSalt, pwHash);
+    }
+
+    private static final char[] rndAllCharacters = new char[]{
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+            'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+            '!', '@', '#', '$', '%', '^', '&', '_', '=', '+'
+    };
+
+    private String getRandomPassword(int length) {
+        SecureRandom random = new SecureRandom();
+        StringBuilder stringBuilder = new StringBuilder();
+
+        int rndAllCharactersLength = rndAllCharacters.length;
+        for (int i = 0; i < length; i++) {
+            stringBuilder.append(rndAllCharacters[random.nextInt(rndAllCharactersLength)]);
+        }
+
+        return stringBuilder.toString();
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/validation/annotation/CheckSocialType.java
+++ b/src/main/java/kr/co/teacherforboss/validation/annotation/CheckSocialType.java
@@ -1,0 +1,21 @@
+package kr.co.teacherforboss.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import kr.co.teacherforboss.validation.validator.CheckSocialTypeValidator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = CheckSocialTypeValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckSocialType {
+    String message() default "소셜 로그인 유형이 아닙니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/kr/co/teacherforboss/validation/validator/CheckSocialTypeValidator.java
+++ b/src/main/java/kr/co/teacherforboss/validation/validator/CheckSocialTypeValidator.java
@@ -1,0 +1,34 @@
+package kr.co.teacherforboss.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import kr.co.teacherforboss.domain.enums.LoginType;
+import kr.co.teacherforboss.validation.annotation.CheckSocialType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CheckSocialTypeValidator implements ConstraintValidator<CheckSocialType, Integer> {
+
+    private String message;
+
+    @Override
+    public void initialize(CheckSocialType constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.message = constraintAnnotation.message();
+    }
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        boolean isValid = LoginType.of(value).equals(LoginType.KAKAO) || LoginType.of(value).equals(LoginType.NAVER);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+        }
+
+        return isValid;
+
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/validation/validator/CheckSocialTypeValidator.java
+++ b/src/main/java/kr/co/teacherforboss/validation/validator/CheckSocialTypeValidator.java
@@ -2,6 +2,7 @@ package kr.co.teacherforboss.validation.validator;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
 import kr.co.teacherforboss.domain.enums.LoginType;
 import kr.co.teacherforboss.validation.annotation.CheckSocialType;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +26,7 @@ public class CheckSocialTypeValidator implements ConstraintValidator<CheckSocial
 
         if (!isValid) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.SOCIAL_TYPE_BAD_REQUEST.toString()).addConstraintViolation();
         }
 
         return isValid;

--- a/src/main/java/kr/co/teacherforboss/web/controller/AuthController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/AuthController.java
@@ -10,6 +10,7 @@ import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.EmailAuth;
 import kr.co.teacherforboss.domain.PhoneAuth;
 import kr.co.teacherforboss.service.authService.AuthCommandService;
+import kr.co.teacherforboss.validation.annotation.CheckSocialType;
 import kr.co.teacherforboss.validation.annotation.ExistPrincipalDetails;
 import kr.co.teacherforboss.web.dto.AuthRequestDTO;
 import kr.co.teacherforboss.web.dto.AuthResponseDTO;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -104,8 +106,9 @@ public class AuthController {
 
     @Validated
     @PostMapping("/login/social")
-    public ApiResponse<AuthResponseDTO.TokenResponseDTO> socialLogin(@RequestBody @Valid AuthRequestDTO.SocialLoginDTO request) {
-        Member member = authCommandService.socialLogin(request);
+    public ApiResponse<AuthResponseDTO.TokenResponseDTO> socialLogin(@RequestBody @Valid AuthRequestDTO.SocialLoginDTO request,
+                                                                     @RequestParam(name = "socialType") @CheckSocialType int socialType) {
+        Member member = authCommandService.socialLogin(request, socialType);
         AuthResponseDTO.TokenResponseDTO tokenResponseDTO = jwtTokenProvider.createTokenResponse(member.getEmail(), member.getRole());
         return ApiResponse.onSuccess(tokenResponseDTO);
     }

--- a/src/main/java/kr/co/teacherforboss/web/controller/AuthController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/AuthController.java
@@ -97,7 +97,7 @@ public class AuthController {
     }
 
     @PatchMapping("/resetPassword")
-    public ApiResponse<AuthResponseDTO.ResetPasswordResultDTO> resetPassword(@RequestBody @Valid AuthRequestDTO.resetPasswordDTO request) {
+    public ApiResponse<AuthResponseDTO.ResetPasswordResultDTO> resetPassword(@RequestBody @Valid AuthRequestDTO.ResetPasswordDTO request) {
         Member member = authCommandService.resetPassword(request);
         return ApiResponse.onSuccess(AuthConverter.toResetPasswordResultDTO(member));
     }

--- a/src/main/java/kr/co/teacherforboss/web/controller/AuthController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/AuthController.java
@@ -101,4 +101,12 @@ public class AuthController {
         Member member = authCommandService.resetPassword(request);
         return ApiResponse.onSuccess(AuthConverter.toResetPasswordResultDTO(member));
     }
+
+    @Validated
+    @PostMapping("/login/social")
+    public ApiResponse<AuthResponseDTO.TokenResponseDTO> socialLogin(@RequestBody @Valid AuthRequestDTO.SocialLoginDTO request) {
+        Member member = authCommandService.socialLogin(request);
+        AuthResponseDTO.TokenResponseDTO tokenResponseDTO = jwtTokenProvider.createTokenResponse(member.getEmail(), member.getRole());
+        return ApiResponse.onSuccess(tokenResponseDTO);
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -120,7 +120,7 @@ public class AuthRequestDTO {
     }
 
     @Getter
-    public static class resetPasswordDTO {
+    public static class ResetPasswordDTO {
         @NotNull(message = "memberId 값이 없습니다.")
         Long memberId;
 

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -145,9 +145,6 @@ public class AuthRequestDTO {
         @NotNull
         String email;
 
-        @NotNull
-        String password;
-
         String name;
 
         @Pattern(regexp = "010([2-9])\\d{7,8}", message = "전화번호는 10 ~ 11 자리의 숫자만 입력 가능합니다.")

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import kr.co.teacherforboss.validation.annotation.CheckSocialType;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.jackson.Jacksonized;
@@ -131,5 +132,31 @@ public class AuthRequestDTO {
         @NotNull
         @Size(min = 8, max = 20, message = "비밀번호를 8~20자 사이로 입력해주세요.")
         String rePassword;
+    }
+
+    @Getter
+    @Builder
+    public static class SocialLoginDTO {
+
+        @CheckSocialType
+        int socialType;
+
+        @Email
+        @NotNull
+        String email;
+
+        @NotNull
+        String password;
+
+        String name;
+
+        @Pattern(regexp = "010([2-9])\\d{7,8}", message = "전화번호는 10 ~ 11 자리의 숫자만 입력 가능합니다.")
+        String phone;
+
+        Integer gender;
+
+        LocalDate birthDate;
+
+        String profileImg;
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import kr.co.teacherforboss.validation.annotation.CheckSocialType;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.jackson.Jacksonized;
@@ -137,9 +136,6 @@ public class AuthRequestDTO {
     @Getter
     @Builder
     public static class SocialLoginDTO {
-
-        @CheckSocialType
-        int socialType;
 
         @Email
         @NotNull


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #41 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/77263479/924fe6ce-88a4-4d17-86d6-87019fda7a2b)

![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/77263479/bd055890-6ac8-4e5e-9a86-d0dee2d6bdd5)


- 네이버, 카카오의 경우 소셜 로그인 진행시 비밀번호를 한번 입력 받기에 password 필드 추가했습니다!
- 소셜 로그인시 email이 필수로 필요하고, 새로 소셜 회원가입을 진행한다면 추가로 name, phone값이 필요하기에 (socialType은 늘 필수, 그 외 값들은 선택) name, phone null값 검증은 서비스단에서 진행했습니다~!
- ResetPasswordDTO 리팩토링 진행
- 소셜 로그인시 프론트에서 비밀번호를 가져올 수 없기에 자바의 SecureRandom을 사용하여 비밀번호 저장


**소셜 로그인 로직**
1. 일반 회원가입으로 등록된 계정인지 확인
2. 소셜 로그인으로 이미 등록된 계정인지 확인
- 등록되어 있다면 바로 로그인 
- 등록되지 않았다면 회원가입 진행


## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

- LoginType kakao(2), naver(3)에 해당하지 않는 int값일 경우 예외 처리 커스텀 어노테이션 추가
- kakao, naver를 제외한 로그인 유형으로 가입한 이메일인 경우 예외처리
- Social 타입으로 회원가입 진행시 name, phone 필수로 기입했는지 여부 확인


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 임시 비밀번호 사이즈를 8로 우선 설정했는데요! (사유: 일반 회원가입시 최소 길이가 8) 이 길이라면 괜찮을까요?
