### PR TITLE
✨[FEAT] 회원가입 Request body 필드 추가

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -58,6 +58,7 @@ public enum ErrorStatus implements BaseErrorCode {
     TIMEOUT_CODE_MAIL(BAD_REQUEST, "AUTH40011", "이메일 인증 유효시간이 만료되었습니다."),
     INVALID_CODE_PHONE(BAD_REQUEST, "AUTH40012", "휴대폰 인증번호가 틀렸습니다."),
     TIMEOUT_CODE_PHONE(BAD_REQUEST, "AUTH40013", "휴대폰 인증 유효시간이 만료되었습니다."),
+    INVALID_AGREEMENT_TERM(BAD_REQUEST, "AUTH40014", "모든 필수 이용 약관에 동의해야 합니다."),
 
     // For test
     TEMP_EXCEPTION(BAD_REQUEST, "TEMP4001", "이거는 테스트");

--- a/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
@@ -7,6 +7,7 @@ import kr.co.teacherforboss.domain.enums.Gender;
 import kr.co.teacherforboss.domain.enums.LoginType;
 import kr.co.teacherforboss.domain.enums.Role;
 import kr.co.teacherforboss.domain.enums.Purpose;
+import kr.co.teacherforboss.domain.mapping.AgreementTerm;
 import kr.co.teacherforboss.web.dto.AuthRequestDTO;
 import kr.co.teacherforboss.web.dto.AuthResponseDTO;
 
@@ -100,6 +101,15 @@ public class AuthConverter {
         return AuthResponseDTO.FindEmailResultDTO.builder()
                 .email(member.getEmail())
                 .createdAt(member.getCreatedAt())
+                .build();
+    }
+
+    public static AgreementTerm toAgreementTerm(AuthRequestDTO.JoinDTO request, Member member) {
+        return AgreementTerm.builder()
+                .member(member)
+                .agreementSms(request.getAgreementSms())
+                .agreementEmail(request.getAgreementEmail())
+                .agreementLocation(request.getAgreementLocation())
                 .build();
     }
 }

--- a/src/main/java/kr/co/teacherforboss/domain/mapping/AgreementTerm.java
+++ b/src/main/java/kr/co/teacherforboss/domain/mapping/AgreementTerm.java
@@ -1,0 +1,40 @@
+package kr.co.teacherforboss.domain.mapping;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AgreementTerm extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId")
+    private Member member;
+
+    @NotNull
+    @Column(length = 1)
+    private String agreementSms;
+
+    @NotNull
+    @Column(length = 1)
+    private String agreementEmail;
+
+    @NotNull
+    @Column(length = 1)
+    private String agreementLocation;
+
+}

--- a/src/main/java/kr/co/teacherforboss/repository/AgreementTermRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/AgreementTermRepository.java
@@ -1,0 +1,9 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.mapping.AgreementTerm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AgreementTermRepository extends JpaRepository<AgreementTerm, Long> {
+}

--- a/src/main/java/kr/co/teacherforboss/validation/annotation/CheckTrueOrFalse.java
+++ b/src/main/java/kr/co/teacherforboss/validation/annotation/CheckTrueOrFalse.java
@@ -1,0 +1,22 @@
+package kr.co.teacherforboss.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import kr.co.teacherforboss.validation.validator.CheckTrueOrFalseValidator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = CheckTrueOrFalseValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckTrueOrFalse {
+    String message() default "T 또는 F 값을 입력해주세요.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    int question() default 0;
+}

--- a/src/main/java/kr/co/teacherforboss/validation/validator/CheckTrueOrFalseValidator.java
+++ b/src/main/java/kr/co/teacherforboss/validation/validator/CheckTrueOrFalseValidator.java
@@ -1,0 +1,33 @@
+package kr.co.teacherforboss.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import kr.co.teacherforboss.validation.annotation.CheckTrueOrFalse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CheckTrueOrFalseValidator implements ConstraintValidator<CheckTrueOrFalse, String> {
+
+    private String message;
+
+    @Override
+    public void initialize(CheckTrueOrFalse constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.message = constraintAnnotation.message();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        boolean isValid = value.equals("T") || value.equals("F");
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+        }
+
+        return isValid;
+
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import kr.co.teacherforboss.validation.annotation.CheckTrueOrFalse;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.jackson.Jacksonized;
@@ -44,6 +45,30 @@ public class AuthRequestDTO {
         Integer gender;
 
         LocalDate birthDate;
+
+        @NotNull(message = "이용 정보 약관 동의는 필수여야 합니다.")
+        @CheckTrueOrFalse
+        String agreementUsage;
+
+        @NotNull(message = "개인 정보 약관 동의는 필수여야 합니다.")
+        @CheckTrueOrFalse
+        String agreementInfo;
+
+        @NotNull(message = "14세 이상 약관 동의는 필수여야 합니다.")
+        @CheckTrueOrFalse
+        String agreementAge;
+
+        @NotNull(message = "SMS 수신 동의 여부를 입력해주세요.")
+        @CheckTrueOrFalse
+        String agreementSms;
+
+        @NotNull(message = "Email 수신 동의 여부를 입력해주세요.")
+        @CheckTrueOrFalse
+        String agreementEmail;
+
+        @NotNull(message = "위치 이용 동의 여부를 입력해주세요.")
+        @CheckTrueOrFalse
+        String agreementLocation;
     }
     
     @Getter


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #51 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/77263479/120272cd-fed5-4f48-8832-4a9e369f8518)

- AgreementTerm 엔티티 추가 & @CheckTrueOrFalse 어노테이션 추가 (T, F 값 검증)
- 회원가입 request body 필드 추가
- 수신 동의 테이블 추가에 따른 회원가입 로직 수정

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

- 회원가입시 필요한 필수 약관동의 모두 T가 아닐시 에러
- 약관동의 관련 필드 모두 T나 F값이 아니면 에러



## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 아놔 생성된 파일 먼저 커밋하니까 나머지 파일들도 올라가버려서 커밋 메세지가.. 저리 단조롭게 엔티티 추가 & 어노테이션 생성으로 마무리 되었네요 회원가입 로직 수정도 추가입니당!
