### PR TITLE
♻️[REFACTOR] @Valid Exception Response 구조 변경

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/ApiResponse.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/ApiResponse.java
@@ -7,9 +7,11 @@ import kr.co.teacherforboss.apiPayload.code.BaseCode;
 import kr.co.teacherforboss.apiPayload.code.status.SuccessStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@RequiredArgsConstructor
 @JsonPropertyOrder({"isSuccess", "code", "message", "result"})
 public class ApiResponse<T> {
 
@@ -33,6 +35,6 @@ public class ApiResponse<T> {
 
     // 실패한 경우 응답 생성
     public static <T> ApiResponse<T> onFailure(String code, String message, T data){
-        return new ApiResponse<>(false, code, message, data);
+        return new ApiResponse<>(false, code, message);
     }
 }

--- a/src/main/java/kr/co/teacherforboss/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/exception/ExceptionAdvice.java
@@ -97,7 +97,8 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
     private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
                                                                WebRequest request, Map<String, String> errorArgs) {
-        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        String errorMessage = String.join(";", errorArgs.values());
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorMessage,errorArgs);
         return super.handleExceptionInternal(
                 e,
                 body,


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #70 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

@Valid 어노테이션에서 실패 시 던지는 Exception의 Response 구조 변경했습니다.

- AS-IS
<img width="881" alt="Screenshot 2024-02-05 at 1 03 25 AM" src="https://github.com/teacher-for-boss/teacher-for-boss-server/assets/79203421/9007bb9e-b8c6-4e73-b0ea-d31fadc30abe">

- TO-BE
<img width="876" alt="Screenshot 2024-02-05 at 1 03 13 AM" src="https://github.com/teacher-for-boss/teacher-for-boss-server/assets/79203421/6b34a20d-08c1-48cd-9933-32cd9b92c043">

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
