### PR TITLE
✨[FEAT] 시험 보기 API 

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -67,6 +67,9 @@ public enum ErrorStatus implements BaseErrorCode {
     EXAM_NOT_FOUND(NOT_FOUND, "EXAM4001", "시험 정보를 찾을 수 없습니다."),
     QUESTION_NOT_FOUND(NOT_FOUND, "EXAM4002", "입력한 ID 값에 해당되는 문제를 찾을 수 없습니다."),
     QUESTION_CHOICE_NOT_FOUND(NOT_FOUND, "EXAM4003", "입력한 ID 값에 해당되는 문제 선지를 찾을 수 없습니다."),
+    MEMBER_EXAM_DUPLICATE(BAD_REQUEST, "EXAM4004", "이미 치룬 시험입니다."),
+    QUESTION_OPTION_NULL(BAD_REQUEST, "EXAM4005", "시험 문제 선지를 모두 선택해주세요."),
+
     // For test
     TEMP_EXCEPTION(BAD_REQUEST, "TEMP4001", "이거는 테스트");
 

--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -68,7 +68,7 @@ public enum ErrorStatus implements BaseErrorCode {
     QUESTION_NOT_FOUND(NOT_FOUND, "EXAM4002", "입력한 ID 값에 해당되는 문제를 찾을 수 없습니다."),
     QUESTION_CHOICE_NOT_FOUND(NOT_FOUND, "EXAM4003", "입력한 ID 값에 해당되는 문제 선지를 찾을 수 없습니다."),
     MEMBER_EXAM_DUPLICATE(BAD_REQUEST, "EXAM4004", "이미 치룬 시험입니다."),
-    QUESTION_OPTION_NULL(BAD_REQUEST, "EXAM4005", "시험 문제 선지를 모두 선택해주세요."),
+    INVALID_QUESTION_CHOICE(BAD_REQUEST, "EXAM4005", "시험 문제 선지를 모두 선택해주세요."),
 
     // For test
     TEMP_EXCEPTION(BAD_REQUEST, "TEMP4001", "이거는 테스트");

--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -63,6 +63,10 @@ public enum ErrorStatus implements BaseErrorCode {
     SOCIAL_TYPE_BAD_REQUEST(BAD_REQUEST, "AUTH40014", "기입한 소셜 로그인 유형과 일치하지 않습니다."),
     INVALID_AGREEMENT_TERM(BAD_REQUEST, "AUTH40015", "모든 필수 이용 약관에 동의해야 합니다."),
 
+    // Exam
+    EXAM_NOT_FOUND(NOT_FOUND, "EXAM4001", "시험 정보를 찾을 수 없습니다."),
+    QUESTION_NOT_FOUND(NOT_FOUND, "EXAM4002", "입력한 ID 값에 해당되는 문제를 찾을 수 없습니다."),
+    QUESTION_CHOICE_NOT_FOUND(NOT_FOUND, "EXAM4003", "입력한 ID 값에 해당되는 문제 선지를 찾을 수 없습니다."),
     // For test
     TEMP_EXCEPTION(BAD_REQUEST, "TEMP4001", "이거는 테스트");
 

--- a/src/main/java/kr/co/teacherforboss/apiPayload/exception/handler/ExamHandler.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/exception/handler/ExamHandler.java
@@ -1,0 +1,10 @@
+package kr.co.teacherforboss.apiPayload.exception.handler;
+
+import kr.co.teacherforboss.apiPayload.code.BaseErrorCode;
+import kr.co.teacherforboss.apiPayload.exception.GeneralException;
+
+public class ExamHandler extends GeneralException {
+    public ExamHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
@@ -7,7 +7,7 @@ import kr.co.teacherforboss.domain.enums.Gender;
 import kr.co.teacherforboss.domain.enums.LoginType;
 import kr.co.teacherforboss.domain.enums.Role;
 import kr.co.teacherforboss.domain.enums.Purpose;
-import kr.co.teacherforboss.domain.mapping.AgreementTerm;
+import kr.co.teacherforboss.domain.AgreementTerm;
 import kr.co.teacherforboss.web.dto.AuthRequestDTO;
 import kr.co.teacherforboss.web.dto.AuthResponseDTO;
 

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -1,0 +1,36 @@
+package kr.co.teacherforboss.converter;
+
+
+import kr.co.teacherforboss.domain.Exam;
+import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.MemberAnswer;
+import kr.co.teacherforboss.domain.MemberExam;
+import kr.co.teacherforboss.domain.Question;
+import kr.co.teacherforboss.domain.QuestionChoice;
+import kr.co.teacherforboss.web.dto.ExamResponseDTO;
+
+import java.time.LocalDateTime;
+
+public class ExamConverter {
+
+    public static ExamResponseDTO.TakeExamsDTO toTakeExamsDTO(MemberExam memberExam) {
+        return ExamResponseDTO.TakeExamsDTO.builder()
+                .memberExamId(memberExam.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static MemberAnswer toMemberAnswerList(Question question, QuestionChoice questionChoice) {
+        return MemberAnswer.builder()
+                .question(question)
+                .questionChoice(questionChoice)
+                .build();
+    }
+
+    public static MemberExam toMemberExam(Member member, Exam exam) {
+        return MemberExam.builder()
+                .member(member)
+                .exam(exam)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -20,7 +20,7 @@ public class ExamConverter {
                 .build();
     }
 
-    public static MemberAnswer toMemberAnswerList(Question question, QuestionChoice questionChoice) {
+    public static MemberAnswer toMemberAnswer(Question question, QuestionChoice questionChoice) {
         return MemberAnswer.builder()
                 .question(question)
                 .questionChoice(questionChoice)

--- a/src/main/java/kr/co/teacherforboss/domain/AgreementTerm.java
+++ b/src/main/java/kr/co/teacherforboss/domain/AgreementTerm.java
@@ -1,4 +1,4 @@
-package kr.co.teacherforboss.domain.mapping;
+package kr.co.teacherforboss.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/kr/co/teacherforboss/domain/Exam.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Exam.java
@@ -1,0 +1,31 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Exam extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "examCategoryId")
+    private ExamCategory examCategory;
+
+    @NotNull
+    @Column(length = 30)
+    private String name;
+
+}

--- a/src/main/java/kr/co/teacherforboss/domain/Exam.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Exam.java
@@ -2,16 +2,22 @@ package kr.co.teacherforboss.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
 import kr.co.teacherforboss.domain.common.BaseEntity;
+import kr.co.teacherforboss.domain.enums.ExamType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -28,4 +34,15 @@ public class Exam extends BaseEntity {
     @Column(length = 30)
     private String name;
 
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)")
+    private ExamType examType;
+
+    @OneToMany(mappedBy = "exam")
+    private List<Question> questionList;
+
+    public void setQuestionList(List<Question> questionList) {
+        this.questionList = questionList;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/domain/ExamCategory.java
+++ b/src/main/java/kr/co/teacherforboss/domain/ExamCategory.java
@@ -2,11 +2,8 @@ package kr.co.teacherforboss.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
 import kr.co.teacherforboss.domain.common.BaseEntity;
-import kr.co.teacherforboss.domain.enums.ExamType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,10 +20,5 @@ public class ExamCategory extends BaseEntity {
     @NotNull
     @Column(length = 10)
     private String categoryName;
-
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(10)")
-    private ExamType examType;
 
 }

--- a/src/main/java/kr/co/teacherforboss/domain/ExamCategory.java
+++ b/src/main/java/kr/co/teacherforboss/domain/ExamCategory.java
@@ -1,0 +1,32 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotNull;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import kr.co.teacherforboss.domain.enums.ExamType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ExamCategory extends BaseEntity {
+
+    @NotNull
+    @Column(length = 10)
+    private String categoryName;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)")
+    private ExamType examType;
+
+}

--- a/src/main/java/kr/co/teacherforboss/domain/MemberAnswer.java
+++ b/src/main/java/kr/co/teacherforboss/domain/MemberAnswer.java
@@ -1,0 +1,37 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberAnswer extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberExamId")
+    private MemberExam memberExam;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "questionId")
+    private Question question;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "questionChoiceId")
+    private QuestionChoice questionChoice;
+
+    public void setMemberExam(MemberExam memberExam) {
+        this.memberExam = memberExam;
+    }
+
+}

--- a/src/main/java/kr/co/teacherforboss/domain/MemberExam.java
+++ b/src/main/java/kr/co/teacherforboss/domain/MemberExam.java
@@ -1,0 +1,38 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberExam extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "examId")
+    private Exam exam;
+
+    @NotNull
+    @Column
+    private Integer score;
+
+    public void setScore(Integer score) {
+        this.score = score;
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/domain/Question.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Question.java
@@ -1,0 +1,49 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.validation.constraints.NotNull;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Question extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "examId")
+    private Exam exam;
+
+    @NotNull
+    @Column(length = 50)
+    private String questionName;
+
+    @NotNull
+    @Column(length = 30)
+    private String answer;
+
+    @NotNull
+    @Column(length = 100)
+    private String commentary;
+
+    @NotNull
+    @Column
+    private Integer points;
+
+    @OneToMany(mappedBy = "question")
+    private List<QuestionChoice> questionOptionList;
+
+}

--- a/src/main/java/kr/co/teacherforboss/domain/QuestionChoice.java
+++ b/src/main/java/kr/co/teacherforboss/domain/QuestionChoice.java
@@ -1,0 +1,30 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class QuestionChoice extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "questionId")
+    private Question question;
+
+    @NotNull
+    @Column(length = 30)
+    private String choice;
+}

--- a/src/main/java/kr/co/teacherforboss/domain/enums/ExamType.java
+++ b/src/main/java/kr/co/teacherforboss/domain/enums/ExamType.java
@@ -1,0 +1,5 @@
+package kr.co.teacherforboss.domain.enums;
+
+public enum ExamType {
+    MID, FINAL
+}

--- a/src/main/java/kr/co/teacherforboss/repository/AgreementTermRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/AgreementTermRepository.java
@@ -1,6 +1,6 @@
 package kr.co.teacherforboss.repository;
 
-import kr.co.teacherforboss.domain.mapping.AgreementTerm;
+import kr.co.teacherforboss.domain.AgreementTerm;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/kr/co/teacherforboss/repository/ExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/ExamRepository.java
@@ -1,0 +1,13 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.Exam;
+import kr.co.teacherforboss.domain.enums.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ExamRepository extends JpaRepository<Exam, Long> {
+    Optional<Exam> findByIdAndStatus(Long examId, Status status);
+}

--- a/src/main/java/kr/co/teacherforboss/repository/MemberAnswerRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberAnswerRepository.java
@@ -1,0 +1,10 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.MemberAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberAnswerRepository extends JpaRepository<MemberAnswer, Long> {
+
+}

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -4,7 +4,9 @@ import kr.co.teacherforboss.domain.MemberExam;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
-
+    boolean existsByMemberIdAndExamId(Long memberId, Long examId);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -1,0 +1,10 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.MemberExam;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
+
+}

--- a/src/main/java/kr/co/teacherforboss/repository/QuestionChoiceRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/QuestionChoiceRepository.java
@@ -1,0 +1,13 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.QuestionChoice;
+import kr.co.teacherforboss.domain.enums.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface QuestionChoiceRepository extends JpaRepository<QuestionChoice, Long> {
+    Optional<QuestionChoice> findByIdAndStatus(Long questionChoiceId, Status status);
+}

--- a/src/main/java/kr/co/teacherforboss/repository/QuestionChoiceRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/QuestionChoiceRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 
 @Repository
 public interface QuestionChoiceRepository extends JpaRepository<QuestionChoice, Long> {
-    Optional<QuestionChoice> findByIdAndStatus(Long questionChoiceId, Status status);
+    Optional<QuestionChoice> findByQuestionIdAndChoiceAndStatus(Long questionId, String choice, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/QuestionChoiceRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/QuestionChoiceRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 
 @Repository
 public interface QuestionChoiceRepository extends JpaRepository<QuestionChoice, Long> {
-    Optional<QuestionChoice> findByQuestionIdAndChoiceAndStatus(Long questionId, String choice, Status status);
+    Optional<QuestionChoice> findByIdAndStatus(Long questionChoiceId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
@@ -1,0 +1,15 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.Question;
+import kr.co.teacherforboss.domain.enums.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+    Optional<List<Question>> findAllByExamIdAndStatus(Long examId, Status status);
+    Optional<Question> findByIdAndStatus(Long questionId, Status status);
+}

--- a/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
-    List<Question> findAllByExamIdAndStatus(Long examId, Status status);
+    Integer countByExamIdAndStatus(Long examId, Status status);
     Optional<Question> findByIdAndStatus(Long questionId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
-    Optional<List<Question>> findAllByExamIdAndStatus(Long examId, Status status);
+    List<Question> findAllByExamIdAndStatus(Long examId, Status status);
     Optional<Question> findByIdAndStatus(Long questionId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
@@ -10,7 +10,7 @@ import kr.co.teacherforboss.apiPayload.exception.handler.MemberHandler;
 import kr.co.teacherforboss.config.jwt.TokenManager;
 import kr.co.teacherforboss.converter.AuthConverter;
 import kr.co.teacherforboss.domain.enums.LoginType;
-import kr.co.teacherforboss.domain.mapping.AgreementTerm;
+import kr.co.teacherforboss.domain.AgreementTerm;
 import kr.co.teacherforboss.repository.AgreementTermRepository;
 import kr.co.teacherforboss.util.PasswordUtil;
 import kr.co.teacherforboss.domain.PhoneAuth;

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandService.java
@@ -1,0 +1,8 @@
+package kr.co.teacherforboss.service.examService;
+
+import kr.co.teacherforboss.domain.MemberExam;
+import kr.co.teacherforboss.web.dto.ExamRequestDTO;
+
+public interface ExamCommandService {
+    MemberExam takeExams(Long examId, ExamRequestDTO.TakeExamsDTO request);
+}

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
@@ -63,11 +63,14 @@ public class ExamCommandServiceImpl implements ExamCommandService {
                     if (question.getAnswer().equals(questionChoice.getChoice()))
                         score.addAndGet(question.getPoints());
 
-                    MemberAnswer memberAnswer =  ExamConverter.toMemberAnswer(question, questionChoice);
-                    memberAnswer.setMemberExam(memberExam);
-                    return memberAnswer;
+                    return ExamConverter.toMemberAnswer(question, questionChoice);
                 }).collect(Collectors.toList());
 
+        memberExam.setScore(score.intValue());
+
+        memberAnswerList.forEach(memberAnswer -> {
+            memberAnswer.setMemberExam(memberExam);
+        });
         memberAnswerRepository.saveAll(memberAnswerList);
 
         return memberExamRepository.save(memberExam);

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
@@ -51,10 +51,10 @@ public class ExamCommandServiceImpl implements ExamCommandService {
                 .map(q -> {
                     Question question = questionRepository.findByIdAndStatus(q.getQuestionId(), Status.ACTIVE)
                             .orElseThrow(() -> new ExamHandler(ErrorStatus.QUESTION_NOT_FOUND));
-                    QuestionChoice questionChoice = questionChoiceRepository.findByIdAndStatus(q.getQuestionChoiceId(), Status.ACTIVE)
+                    QuestionChoice questionChoice = questionChoiceRepository.findByQuestionIdAndChoiceAndStatus(q.getQuestionId(), q.getQuestionChoice(), Status.ACTIVE)
                             .orElseThrow(() -> new ExamHandler(ErrorStatus.QUESTION_CHOICE_NOT_FOUND));
 
-                    if (question.getAnswer().equals(questionChoice.getChoice()))
+                    if (question.getAnswer().equals(q.getQuestionChoice()))
                         score.addAndGet(question.getPoints());
 
                     return ExamConverter.toMemberAnswerList(question, questionChoice);

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
@@ -1,0 +1,71 @@
+package kr.co.teacherforboss.service.examService;
+
+import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
+import kr.co.teacherforboss.apiPayload.exception.handler.ExamHandler;
+import kr.co.teacherforboss.converter.ExamConverter;
+import kr.co.teacherforboss.domain.Exam;
+import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.MemberAnswer;
+import kr.co.teacherforboss.domain.MemberExam;
+import kr.co.teacherforboss.domain.Question;
+import kr.co.teacherforboss.domain.QuestionChoice;
+import kr.co.teacherforboss.domain.enums.Status;
+import kr.co.teacherforboss.repository.ExamRepository;
+import kr.co.teacherforboss.repository.MemberAnswerRepository;
+import kr.co.teacherforboss.repository.MemberExamRepository;
+import kr.co.teacherforboss.repository.QuestionChoiceRepository;
+import kr.co.teacherforboss.repository.QuestionRepository;
+import kr.co.teacherforboss.service.authService.AuthCommandService;
+import kr.co.teacherforboss.web.dto.ExamRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ExamCommandServiceImpl implements ExamCommandService {
+
+    private final QuestionRepository questionRepository;
+    private final QuestionChoiceRepository questionChoiceRepository;
+    private final ExamRepository examRepository;
+    private final MemberExamRepository memberExamRepository;
+    private final MemberAnswerRepository memberAnswerRepository;
+    private final AuthCommandService authCommandService;
+
+    @Override
+    @Transactional
+    public MemberExam takeExams(Long examId, ExamRequestDTO.TakeExamsDTO request) {
+        Member member = authCommandService.getMember();
+        AtomicInteger score = new AtomicInteger(0);
+
+        Exam exam = examRepository.findByIdAndStatus(examId, Status.ACTIVE)
+                .orElseThrow(() -> new ExamHandler(ErrorStatus.EXAM_NOT_FOUND));
+
+        MemberExam memberExam = ExamConverter.toMemberExam(member, exam);
+
+        List<MemberAnswer> memberAnswerList = request.getQuestionAnsList().stream()
+                .map(q -> {
+                    Question question = questionRepository.findByIdAndStatus(q.getQuestionId(), Status.ACTIVE)
+                            .orElseThrow(() -> new ExamHandler(ErrorStatus.QUESTION_NOT_FOUND));
+                    QuestionChoice questionChoice = questionChoiceRepository.findByIdAndStatus(q.getQuestionChoiceId(), Status.ACTIVE)
+                            .orElseThrow(() -> new ExamHandler(ErrorStatus.QUESTION_CHOICE_NOT_FOUND));
+
+                    if (question.getAnswer().equals(questionChoice.getChoice()))
+                        score.addAndGet(question.getPoints());
+
+                    return ExamConverter.toMemberAnswerList(question, questionChoice);
+
+                }).collect(Collectors.toList());
+
+        memberExam.setScore(score.intValue());
+
+        memberAnswerList.forEach(memberAnswer -> {memberAnswer.setMemberExam(memberExam);});
+        memberAnswerRepository.saveAll(memberAnswerList);
+
+        return memberExamRepository.save(memberExam);
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
@@ -49,7 +49,7 @@ public class ExamCommandServiceImpl implements ExamCommandService {
             throw new ExamHandler(ErrorStatus.MEMBER_EXAM_DUPLICATE);
 
         if (questionRepository.findAllByExamIdAndStatus(examId, Status.ACTIVE).size() != request.getQuestionAnsList().size())
-            throw new ExamHandler(ErrorStatus.QUESTION_OPTION_NULL);
+            throw new ExamHandler(ErrorStatus.INVALID_QUESTION_CHOICE);
 
         MemberExam memberExam = ExamConverter.toMemberExam(member, exam);
 
@@ -57,13 +57,13 @@ public class ExamCommandServiceImpl implements ExamCommandService {
                 .map(q -> {
                     Question question = questionRepository.findByIdAndStatus(q.getQuestionId(), Status.ACTIVE)
                             .orElseThrow(() -> new ExamHandler(ErrorStatus.QUESTION_NOT_FOUND));
-                    QuestionChoice questionChoice = questionChoiceRepository.findByQuestionIdAndChoiceAndStatus(q.getQuestionId(), q.getQuestionChoice(), Status.ACTIVE)
+                    QuestionChoice questionChoice = questionChoiceRepository.findByIdAndStatus(q.getQuestionChoiceId(), Status.ACTIVE)
                             .orElseThrow(() -> new ExamHandler(ErrorStatus.QUESTION_CHOICE_NOT_FOUND));
 
-                    if (question.getAnswer().equals(q.getQuestionChoice()))
+                    if (question.getAnswer().equals(questionChoice.getChoice()))
                         score.addAndGet(question.getPoints());
 
-                    return ExamConverter.toMemberAnswerList(question, questionChoice);
+                    return ExamConverter.toMemberAnswer(question, questionChoice);
 
                 }).collect(Collectors.toList());
 

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
@@ -48,7 +48,7 @@ public class ExamCommandServiceImpl implements ExamCommandService {
         if (memberExamRepository.existsByMemberIdAndExamId(member.getId(), examId))
             throw new ExamHandler(ErrorStatus.MEMBER_EXAM_DUPLICATE);
 
-        if (questionRepository.findAllByExamIdAndStatus(examId, Status.ACTIVE).size() != request.getQuestionAnsList().size())
+        if (questionRepository.countByExamIdAndStatus(examId, Status.ACTIVE) != request.getQuestionAnsList().size())
             throw new ExamHandler(ErrorStatus.INVALID_QUESTION_CHOICE);
 
         MemberExam memberExam = ExamConverter.toMemberExam(member, exam);
@@ -63,13 +63,11 @@ public class ExamCommandServiceImpl implements ExamCommandService {
                     if (question.getAnswer().equals(questionChoice.getChoice()))
                         score.addAndGet(question.getPoints());
 
-                    return ExamConverter.toMemberAnswer(question, questionChoice);
-
+                    MemberAnswer memberAnswer =  ExamConverter.toMemberAnswer(question, questionChoice);
+                    memberAnswer.setMemberExam(memberExam);
+                    return memberAnswer;
                 }).collect(Collectors.toList());
 
-        memberExam.setScore(score.intValue());
-
-        memberAnswerList.forEach(memberAnswer -> {memberAnswer.setMemberExam(memberExam);});
         memberAnswerRepository.saveAll(memberAnswerList);
 
         return memberExamRepository.save(memberExam);

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
@@ -45,6 +45,12 @@ public class ExamCommandServiceImpl implements ExamCommandService {
         Exam exam = examRepository.findByIdAndStatus(examId, Status.ACTIVE)
                 .orElseThrow(() -> new ExamHandler(ErrorStatus.EXAM_NOT_FOUND));
 
+        if (memberExamRepository.existsByMemberIdAndExamId(member.getId(), examId))
+            throw new ExamHandler(ErrorStatus.MEMBER_EXAM_DUPLICATE);
+
+        if (questionRepository.findAllByExamIdAndStatus(examId, Status.ACTIVE).size() != request.getQuestionAnsList().size())
+            throw new ExamHandler(ErrorStatus.QUESTION_OPTION_NULL);
+
         MemberExam memberExam = ExamConverter.toMemberExam(member, exam);
 
         List<MemberAnswer> memberAnswerList = request.getQuestionAnsList().stream()

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
@@ -63,14 +63,12 @@ public class ExamCommandServiceImpl implements ExamCommandService {
                     if (question.getAnswer().equals(questionChoice.getChoice()))
                         score.addAndGet(question.getPoints());
 
-                    return ExamConverter.toMemberAnswer(question, questionChoice);
+                    MemberAnswer memberAnswer = ExamConverter.toMemberAnswer(question, questionChoice);
+                    memberAnswer.setMemberExam(memberExam);
+                    return memberAnswer;
                 }).collect(Collectors.toList());
 
         memberExam.setScore(score.intValue());
-
-        memberAnswerList.forEach(memberAnswer -> {
-            memberAnswer.setMemberExam(memberExam);
-        });
         memberAnswerRepository.saveAll(memberAnswerList);
 
         return memberExamRepository.save(memberExam);

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -1,0 +1,32 @@
+package kr.co.teacherforboss.web.controller;
+
+import jakarta.validation.Valid;
+import kr.co.teacherforboss.apiPayload.ApiResponse;
+import kr.co.teacherforboss.converter.ExamConverter;
+import kr.co.teacherforboss.domain.MemberExam;
+import kr.co.teacherforboss.service.examService.ExamCommandService;
+import kr.co.teacherforboss.web.dto.ExamRequestDTO;
+import kr.co.teacherforboss.web.dto.ExamResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Validated
+@RestController
+@RequestMapping("api/v1/exams")
+@RequiredArgsConstructor
+public class ExamController {
+    private final ExamCommandService examCommandService;
+
+    @PostMapping("/{examId}")
+    public ApiResponse<ExamResponseDTO.TakeExamsDTO> takeExams(@PathVariable("examId") Long examId, @RequestBody @Valid ExamRequestDTO.TakeExamsDTO request) {
+        MemberExam memberExam = examCommandService.takeExams(examId, request);
+        return ApiResponse.onSuccess(ExamConverter.toTakeExamsDTO(memberExam));
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -25,7 +25,7 @@ public class ExamController {
     private final ExamCommandService examCommandService;
 
     @PostMapping("/{examId}")
-    public ApiResponse<ExamResponseDTO.TakeExamsDTO> takeExams(@PathVariable("examId") Long examId, @RequestBody @Valid ExamRequestDTO.TakeExamsDTO request) {
+    public ApiResponse<ExamResponseDTO.TakeExamsDTO> takeExam(@PathVariable("examId") Long examId, @RequestBody @Valid ExamRequestDTO.TakeExamsDTO request) {
         MemberExam memberExam = examCommandService.takeExams(examId, request);
         return ApiResponse.onSuccess(ExamConverter.toTakeExamsDTO(memberExam));
     }

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamRequestDTO.java
@@ -29,6 +29,6 @@ public class ExamRequestDTO {
         Long questionId;
 
         @NotNull
-        Long questionChoiceId;
+        String questionChoice;
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamRequestDTO.java
@@ -29,6 +29,6 @@ public class ExamRequestDTO {
         Long questionId;
 
         @NotNull
-        String questionChoice;
+        Long questionChoiceId;
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamRequestDTO.java
@@ -1,0 +1,34 @@
+package kr.co.teacherforboss.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+
+public class ExamRequestDTO {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class TakeExamsDTO{
+
+        @NotNull
+        List<TakeExamsChoicesDTO> questionAnsList;
+
+    }
+
+    @Getter
+    @Builder
+    public static class TakeExamsChoicesDTO{
+        @NotNull
+        Long questionId;
+
+        @NotNull
+        Long questionChoiceId;
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
@@ -1,0 +1,19 @@
+package kr.co.teacherforboss.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class ExamResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TakeExamsDTO{
+        Long memberExamId;
+        LocalDateTime createdAt;
+    }
+}

--- a/src/test/java/kr/co/teacherforboss/repository/questionRepository/QuestionRepositoryTest.java
+++ b/src/test/java/kr/co/teacherforboss/repository/questionRepository/QuestionRepositoryTest.java
@@ -1,0 +1,71 @@
+package kr.co.teacherforboss.repository.questionRepository;
+
+import kr.co.teacherforboss.domain.Exam;
+import kr.co.teacherforboss.domain.Question;
+import kr.co.teacherforboss.domain.enums.ExamType;
+import kr.co.teacherforboss.domain.enums.Status;
+import kr.co.teacherforboss.repository.ExamRepository;
+import kr.co.teacherforboss.repository.QuestionRepository;
+import kr.co.teacherforboss.util.ExamTestUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.FactoryBasedNavigableListAssert.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class QuestionRepositoryTest {
+
+    @Mock
+    private ExamRepository examRepository;
+    @Mock
+    private QuestionRepository questionRepository;
+    @InjectMocks
+    private ExamTestUtil examTestUtil;
+
+    /*
+    // TODO: 문제 조회 성능 테스트
+     */
+    @DisplayName("문제 조회 성능 비교 - count vs 연관관계 조회")
+    @Test
+    void countByExamIdAndStatus() {
+        // given
+        Exam exam = examTestUtil.generateExam(ExamType.MID);
+        List<Question> questionList = new ArrayList<>();
+        IntStream.rangeClosed(1, 1000000)
+                .forEach(i -> questionList.add(examTestUtil.generateQuestion(exam, "문제" + i, "답" + i)));
+        exam.setQuestionList(questionList);
+
+        examRepository.save(exam);
+        questionRepository.saveAll(questionList);
+
+        // when
+        long start0 = System.currentTimeMillis();
+        questionRepository.findAll();
+        long end0 = System.currentTimeMillis();
+        long elapsedTime0 = end0 - start0;
+
+        long start1 = System.currentTimeMillis();
+        if (examRepository.findByIdAndStatus(exam.getId(), Status.ACTIVE).isPresent())
+            examRepository.findByIdAndStatus(exam.getId(), Status.ACTIVE).get().getQuestionList(); // 시험 Id 조회 -> 시험의 question list 조회
+        long end1 = System.currentTimeMillis();
+        long elapsedTime1 = end1 - start1;
+
+        long start2 = System.currentTimeMillis();
+        questionRepository.countByExamIdAndStatus(exam.getId(), Status.ACTIVE); // 시험 Id가 동일한 문제들 조회
+        long end2 = System.currentTimeMillis();
+        long elapsedTime2 = end2 - start2;
+
+        // then
+        System.out.println("Query execution time0: " + elapsedTime0 + " millisecond0");
+        System.out.println("Query execution time1: " + elapsedTime1 + " milliseconds");
+        System.out.println("Query execution time2: " + elapsedTime2 + " milliseconds");
+    }
+}

--- a/src/test/java/kr/co/teacherforboss/util/ExamTestUtil.java
+++ b/src/test/java/kr/co/teacherforboss/util/ExamTestUtil.java
@@ -1,0 +1,37 @@
+package kr.co.teacherforboss.util;
+
+import kr.co.teacherforboss.domain.Exam;
+import kr.co.teacherforboss.domain.ExamCategory;
+import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.MemberAnswer;
+import kr.co.teacherforboss.domain.MemberExam;
+import kr.co.teacherforboss.domain.Question;
+import kr.co.teacherforboss.domain.QuestionChoice;
+import kr.co.teacherforboss.domain.enums.ExamType;
+
+public class ExamTestUtil {
+
+    public ExamCategory generateExamCategory() {
+        return ExamCategory.builder()
+                .categoryName("카테고리")
+                .build();
+    }
+    public Exam generateExam(ExamType examType) {
+        ExamCategory examCategory = generateExamCategory();
+        return Exam.builder()
+                .examType(examType)
+                .name("시험 1")
+                .examCategory(examCategory)
+                .build();
+    }
+
+    public Question generateQuestion(Exam exam, String questionName, String answer) {
+        return Question.builder()
+                .exam(exam)
+                .questionName(questionName)
+                .answer(answer)
+                .points(10)
+                .commentary("해설")
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #77 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/77263479/816c3b07-b7f1-42a3-b479-ae9718a7546f)
![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/77263479/0b6a5052-424a-401c-b225-99b649c13911)

- 초기 입력받은 검증된 Member 객체와 examId로 MemberExam 객체 생성
- body로 입력받은 questionAnsList의 questionId (question), questionOptionId (questionChoice)로 DB에 존재하는지 검증 후 답이 맞을 시 score 점수 추가 (lambda 동시성 이슈로 score를 AtomicInteger type으로 선언)
- question, questionChoice로 MemberAnswer 객체 생성하여 람다식으로 리스트로 묶어냄 (-> MemberAnsList)
- MemberAnsList 리스트 객체에 MemberExam 객체 할당한 후  DB에 모두 저장
- 마찬가지로 score 값 저장한 MemberExam 객체 또한 DB에 저장


## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

- 시험 Id, 문제 Id, 선지 Id가 존재하지 않는 경우 예외 처리
- 시험 중복 제출 예외 처리
- 모든 시험 문제에 대해 선지 선택 안할 시 예외 처리

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 엔티티 컬럼 사이즈 괜찮을까요?
- 서비스 로직 이상하거나 좀 더 수정하고 싶은 부분 있다면 알려주세요! 테스트 코드도 이어서 올리겠습니당
- 프론트에서 API 개수 리소스 차이 때문에 body값을 Id보다 String으로 전달하는게 좋다고 하셔서 우선 선지 부분만 String으로 받도록 하였습니다!
