### PR TITLE
❤️‍🩹 #102 Fix: 시험 문제 리스트 조회 시 문제순서순 정렬 추가

### DIFF
--- a/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import kr.co.teacherforboss.domain.Question;
 import kr.co.teacherforboss.domain.enums.Status;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,5 +12,5 @@ import org.springframework.stereotype.Repository;
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     Integer countByExamIdAndStatus(Long examId, Status status);
     Optional<Question> findByIdAndStatus(Long questionId, Status status);
-    List<Question> findAllByExamIdAndStatus(Long examId, Status status);
+    List<Question> findAllByExamIdAndStatus(Long examId, Status status, Sort sort);
 }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -11,6 +11,7 @@ import kr.co.teacherforboss.repository.ExamCategoryRepository;
 import kr.co.teacherforboss.repository.ExamRepository;
 import kr.co.teacherforboss.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +35,6 @@ public class ExamQueryServiceImpl implements ExamQueryService {
         if (!examRepository.existsByIdAndStatus(examId, Status.ACTIVE))
             throw new ExamHandler(ErrorStatus.EXAM_NOT_FOUND);
 
-        return questionRepository.findAllByExamIdAndStatus(examId, Status.ACTIVE);
+        return questionRepository.findAllByExamIdAndStatus(examId, Status.ACTIVE, Sort.by(Sort.Order.asc("questionSequence")));
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #102 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 시험 문제 리스트 조회 시 문제 순서순 정렬 추가

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
