### PR TITLE
✨[FEAT] RedisConfig 파일 추가

### DIFF
--- a/src/main/java/kr/co/teacherforboss/config/RedisConfig.java
+++ b/src/main/java/kr/co/teacherforboss/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package kr.co.teacherforboss.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+        return new LettuceConnectionFactory(configuration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}
+


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #106 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Redis Config 추가
  - Redis Config 를 별도로 추가하지 않더라도, Spring Boot에서 자동으로 구성을 설정해줌
  - 자동 구성 vs 별도 Redis Config
    - 자동 구성 시 기본적으로 JdkSerializationRedisSerializer를 사용하여 키와 값을 직렬화
      -> Java 객체를 Redis에 저장하고 검색할 때 유용하지만, 저장된 데이터를 Redis CLI 등으로 직접 조회했을 때 가독성이 떨어지는 단점
    - 작성한 Redis Config 에서는 StringRedisSerializer를 사용
      -> Redis에 저장된 데이터를 더 쉽게 읽고 이해할 수 있으며, 이는 특히 문자열 데이터를 주로 다루는 경우에 유용

=> 우리는 문자열 데이터(refresh token)를 주로 다루기 때문에 커스텀한 config가 더 유용할 것이라 판단함
 +) 또한 잘 저장되었는지 확인하기 위해 redis CLI를 할 때에서 보기 편할 것이라 생각함
## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
