### PR TITLE
✨[FEAT] MemberExam에 time 컬럼 추가 및 시험 보기 리팩토링

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -71,8 +71,9 @@ public enum ErrorStatus implements BaseErrorCode {
     QUESTION_NOT_FOUND(NOT_FOUND, "EXAM4002", "입력한 ID 값에 해당되는 문제를 찾을 수 없습니다."),
     QUESTION_CHOICE_NOT_FOUND(NOT_FOUND, "EXAM4003", "입력한 ID 값에 해당되는 문제 선지를 찾을 수 없습니다."),
     MEMBER_EXAM_DUPLICATE(BAD_REQUEST, "EXAM4004", "이미 치룬 시험입니다."),
-    INVALID_QUESTION_CHOICE(BAD_REQUEST, "EXAM4005", "시험 문제 선지를 모두 선택해주세요."),
+    INVALID_EXAM_TAKE(BAD_REQUEST, "EXAM4005", "풀지 않은 문제가 있거나 문제가 너무 많습니다."),
     MEMBER_EXAM_NOT_FOUND(NOT_FOUND, "EXAM4006", "사용자가 치루지 않은 시험입니다."),
+    INVALID_QUESTION_CHOICE(NOT_FOUND, "EXAM4007", "문제에 맞지 않는 선지를 선택했습니다."),
 
     // For test
     TEMP_EXCEPTION(BAD_REQUEST, "TEMP4001", "이거는 테스트");

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -21,17 +21,19 @@ public class ExamConverter {
                 .build();
     }
 
-    public static MemberAnswer toMemberAnswer(Question question, QuestionChoice questionChoice) {
+    public static MemberAnswer toMemberAnswer(MemberExam memberExam, Question question, QuestionChoice questionChoice) {
         return MemberAnswer.builder()
+                .memberExam(memberExam)
                 .question(question)
                 .questionChoice(questionChoice)
                 .build();
     }
 
-    public static MemberExam toMemberExam(Member member, Exam exam) {
+    public static MemberExam toMemberExam(Member member, Exam exam, int score) {
         return MemberExam.builder()
                 .member(member)
                 .exam(exam)
+                .score(score)
                 .build();
     }
 

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -14,8 +14,8 @@ import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 
 public class ExamConverter {
 
-    public static ExamResponseDTO.TakeExamsDTO toTakeExamsDTO(MemberExam memberExam) {
-        return ExamResponseDTO.TakeExamsDTO.builder()
+    public static ExamResponseDTO.TakeExamDTO toTakeExamDTO(MemberExam memberExam) {
+        return ExamResponseDTO.TakeExamDTO.builder()
                 .memberExamId(memberExam.getId())
                 .createdAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -29,11 +29,12 @@ public class ExamConverter {
                 .build();
     }
 
-    public static MemberExam toMemberExam(Member member, Exam exam, int score) {
+    public static MemberExam toMemberExam(Member member, Exam exam, int score, long leftTime) {
         return MemberExam.builder()
                 .member(member)
                 .exam(exam)
                 .score(score)
+                .time(MemberExam.TIME_LIMIT - leftTime)
                 .build();
     }
 

--- a/src/main/java/kr/co/teacherforboss/domain/MemberAnswer.java
+++ b/src/main/java/kr/co/teacherforboss/domain/MemberAnswer.java
@@ -30,8 +30,4 @@ public class MemberAnswer extends BaseEntity {
     @JoinColumn(name = "questionChoiceId")
     private QuestionChoice questionChoice;
 
-    public void setMemberExam(MemberExam memberExam) {
-        this.memberExam = memberExam;
-    }
-
 }

--- a/src/main/java/kr/co/teacherforboss/domain/MemberExam.java
+++ b/src/main/java/kr/co/teacherforboss/domain/MemberExam.java
@@ -32,6 +32,10 @@ public class MemberExam extends BaseEntity {
     @Column
     private Integer score;
 
+    @NotNull
+    @Column
+    private Long time;
+
     public void setScore(Integer score) {
         this.score = score;
     }

--- a/src/main/java/kr/co/teacherforboss/domain/MemberExam.java
+++ b/src/main/java/kr/co/teacherforboss/domain/MemberExam.java
@@ -20,6 +20,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MemberExam extends BaseEntity {
 
+    public static final long TIME_LIMIT = 1000 * 60 * 10L; // 10분 (millis)
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memberId")
     private Member member;
@@ -34,6 +36,6 @@ public class MemberExam extends BaseEntity {
 
     @NotNull
     @Column
-    private Long time;
+    private Long time = 600000L;
 
 }

--- a/src/main/java/kr/co/teacherforboss/domain/MemberExam.java
+++ b/src/main/java/kr/co/teacherforboss/domain/MemberExam.java
@@ -36,7 +36,4 @@ public class MemberExam extends BaseEntity {
     @Column
     private Long time;
 
-    public void setScore(Integer score) {
-        this.score = score;
-    }
 }

--- a/src/main/java/kr/co/teacherforboss/domain/QuestionChoice.java
+++ b/src/main/java/kr/co/teacherforboss/domain/QuestionChoice.java
@@ -27,4 +27,8 @@ public class QuestionChoice extends BaseEntity {
     @NotNull
     @Column(length = 30)
     private String choice;
+
+    public boolean isCorrect() {
+        return question.getAnswer().equals(this.getId());
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/repository/QuestionChoiceRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/QuestionChoiceRepository.java
@@ -1,13 +1,14 @@
 package kr.co.teacherforboss.repository;
 
+import java.util.List;
+import java.util.Optional;
 import kr.co.teacherforboss.domain.QuestionChoice;
 import kr.co.teacherforboss.domain.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
 public interface QuestionChoiceRepository extends JpaRepository<QuestionChoice, Long> {
     Optional<QuestionChoice> findByIdAndStatus(Long questionChoiceId, Status status);
+    List<QuestionChoice> findByIdInAndStatus(List<Long> idCollect, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
@@ -12,4 +12,5 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     Integer countByExamIdAndStatus(Long examId, Status status);
     Optional<Question> findByIdAndStatus(Long questionId, Status status);
     List<Question> findAllByExamIdAndStatus(Long examId, Status status);
+    List<Question> findByIdInAndStatus(List<Long> idCollect, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandService.java
@@ -7,7 +7,7 @@ import kr.co.teacherforboss.web.dto.ExamRequestDTO;
 import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 
 public interface ExamCommandService {
-    MemberExam takeExams(Long examId, ExamRequestDTO.TakeExamsDTO request);
+    MemberExam takeExam(Long examId, ExamRequestDTO.TakeExamDTO request);
 
     ExamResponseDTO.GetExamResultDTO getExamResult(Long examId);
 

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
@@ -72,8 +72,8 @@ public class ExamCommandServiceImpl implements ExamCommandService {
         request.getQuestionAnsList().forEach(q -> {
             Question question = questionMap.get(q.getQuestionId());
             QuestionChoice questionChoice = questionChoiceMap.get(q.getQuestionChoiceId());
-            QuestionChoice questionChoice = questionChoiceRepository.findByIdAndStatus(q.getQuestionChoiceId(), Status.ACTIVE)
-                    .orElseThrow(() -> new ExamHandler(ErrorStatus.QUESTION_CHOICE_NOT_FOUND));
+            if (!questionChoice.getQuestion().getId().equals(question.getId()))
+                throw new ExamHandler(ErrorStatus.INVALID_QUESTION_CHOICE);
             if (questionChoice.isCorrect()) {
                 score.addAndGet(question.getPoints());
             }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
@@ -38,7 +38,7 @@ public class ExamCommandServiceImpl implements ExamCommandService {
 
     @Override
     @Transactional
-    public MemberExam takeExams(Long examId, ExamRequestDTO.TakeExamsDTO request) {
+    public MemberExam takeExam(Long examId, ExamRequestDTO.TakeExamDTO request) {
         Member member = authCommandService.getMember();
         AtomicInteger score = new AtomicInteger(0);
 

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
@@ -71,7 +71,7 @@ public class ExamCommandServiceImpl implements ExamCommandService {
             QuestionChoice questionChoice = questionChoiceRepository.findByIdAndStatus(q.getQuestionChoiceId(), Status.ACTIVE)
                     .orElseThrow(() -> new ExamHandler(ErrorStatus.QUESTION_CHOICE_NOT_FOUND));
             return ExamConverter.toMemberAnswer(memberExam, question, questionChoice);
-        }).collect(Collectors.toList());
+        }).toList();
         memberAnswerRepository.saveAll(memberAnswerList);
 
         return memberExamRepository.save(memberExam);

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
@@ -63,7 +63,7 @@ public class ExamCommandServiceImpl implements ExamCommandService {
             }
         });
 
-        MemberExam memberExam = ExamConverter.toMemberExam(member, exam, score.intValue());
+        MemberExam memberExam = ExamConverter.toMemberExam(member, exam, score.intValue(), request.getLeftTime());
 
         List<MemberAnswer> memberAnswerList = request.getQuestionAnsList().stream().map(q -> {
             Question question = questionRepository.findByIdAndStatus(q.getQuestionId(), Status.ACTIVE)

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -32,9 +32,9 @@ public class ExamController {
     private final ExamQueryService examQueryService;
 
     @PostMapping("/{examId}")
-    public ApiResponse<ExamResponseDTO.TakeExamsDTO> takeExam(@PathVariable("examId") Long examId, @RequestBody @Valid ExamRequestDTO.TakeExamsDTO request) {
-        MemberExam memberExam = examCommandService.takeExams(examId, request);
-        return ApiResponse.onSuccess(ExamConverter.toTakeExamsDTO(memberExam));
+    public ApiResponse<ExamResponseDTO.TakeExamDTO> takeExam(@PathVariable("examId") Long examId, @RequestBody @Valid ExamRequestDTO.TakeExamDTO request) {
+        MemberExam memberExam = examCommandService.takeExam(examId, request);
+        return ApiResponse.onSuccess(ExamConverter.toTakeExamDTO(memberExam));
     }
 
     @GetMapping("/{examId}/result")

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamRequestDTO.java
@@ -15,16 +15,16 @@ public class ExamRequestDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    public static class TakeExamsDTO{
+    public static class TakeExamDTO{
 
         @NotNull
-        List<TakeExamsChoicesDTO> questionAnsList;
+        List<TakeExamChoiceDTO> questionAnsList;
 
     }
 
     @Getter
     @Builder
-    public static class TakeExamsChoicesDTO{
+    public static class TakeExamChoiceDTO{
         @NotNull
         Long questionId;
 

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamRequestDTO.java
@@ -17,7 +17,7 @@ public class ExamRequestDTO {
     @Builder
     public static class TakeExamDTO{
 
-        @NotNull
+        @NotNull(message = "문항 정답 리스트는 필수 입력값입니다.")
         List<TakeExamChoiceDTO> questionAnsList;
 
         @NotNull(message = "남은 시간은 필수 입력값입니다.")
@@ -28,10 +28,10 @@ public class ExamRequestDTO {
     @Getter
     @Builder
     public static class TakeExamChoiceDTO{
-        @NotNull
+        @NotNull(message = "문항 식별자는 필수 입력값입니다.")
         Long questionId;
 
-        @NotNull
+        @NotNull(message = "문항 선지 식별자는 필수 입력값입니다.")
         Long questionChoiceId;
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamRequestDTO.java
@@ -20,6 +20,9 @@ public class ExamRequestDTO {
         @NotNull
         List<TakeExamChoiceDTO> questionAnsList;
 
+        @NotNull(message = "남은 시간은 필수 입력값입니다.")
+        Long leftTime;
+
     }
 
     @Getter

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
@@ -12,7 +12,7 @@ public class ExamResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class TakeExamsDTO {
+    public static class TakeExamDTO {
         Long memberExamId;
         LocalDateTime createdAt;
     }


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #103 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- MemberExam에 time(걸린 시간) 컬럼 추가
- 시험 보기 리팩토링
  - 기존에 사용했던 setScore()와 setMemberExam()은 추후 변경될 일이 없음에도 변경 가능성을 열어두는 것이기 때문에 해당 세터 메서드를 사용하지 않도록 수정함
  - 수정된 코드에서 처음에 한 번 repository에서 조회해서 Map에 Question과 QuestionChoice를 저장해두는 방식을 사용함.
    - Question과 QuestionChoice를 repository에서 조회하는 코드가 2번씩 반복되게 짤 수도 있지만, 동일한 세션임에도 1차 캐시를 사용하는지 확실하게 여부를 확인할 수 없었음 (커맨드 로그에는 쿼리가 중복으로 호출되는 것처럼 보임)

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

시험 보기 서비스 부분 봐주세요.. 😭
총 3번 리팩토링 했는데..
1. setter 제거, repository에서 Question 및 QuestionChoice 중복 조회 발생
2. 처음에 Map을 만들어 repository에서 Question과 QuestionChocie를 한 번만 조회하고 뒤에서는 Map에서 조회하도록 수정
  Question과 QuestionChoice를 Map에서 조회하는 과정에서 null 체크 후 Error를 던지는 코드가 중복됨
```java
        Map<Long, Question> questionMap = questionRepository.findByIdInAndStatus(
                        request.getQuestionAnsList().stream()
                                .map(ExamRequestDTO.TakeExamChoiceDTO::getQuestionId)
                                .toList(),
                        Status.ACTIVE)
                .stream().collect(Collectors.toMap(Question::getId, Function.identity()));

        Map<Long, QuestionChoice> choiceMap = questionChoiceRepository.findByIdInAndStatus(
                        request.getQuestionAnsList().stream()
                                .map(ExamRequestDTO.TakeExamChoiceDTO::getQuestionChoiceId)
                                .toList(),
                        Status.ACTIVE)
                .stream().collect(Collectors.toMap(QuestionChoice::getId, Function.identity()));


        AtomicInteger score = new AtomicInteger(0);
        request.getQuestionAnsList().forEach(q -> {
            Question question = Optional.ofNullable(questionMap.get(q.getQuestionId()))
                    .orElseThrow(() -> new ExamHandler(ErrorStatus.QUESTION_NOT_FOUND));
            QuestionChoice questionChoice = Optional.ofNullable(choiceMap.get(q.getQuestionChoiceId()))
                    .orElseThrow(() -> new ExamHandler(ErrorStatus.QUESTION_CHOICE_NOT_FOUND));

            if (question.getAnswer().equals(questionChoice.getId())) {
                score.addAndGet(question.getPoints());
            }
        });

        MemberExam memberExam = ExamConverter.toMemberExam(member, exam, score.intValue(), request.getLeftTime());

        List<MemberAnswer> memberAnswerList = request.getQuestionAnsList().stream().map(q -> {
            Question question = Optional.ofNullable(questionMap.get(q.getQuestionId()))
                    .orElseThrow(() -> new ExamHandler(ErrorStatus.QUESTION_NOT_FOUND));
            QuestionChoice questionChoice = Optional.ofNullable(choiceMap.get(q.getQuestionChoiceId()))
                    .orElseThrow(() -> new ExamHandler(ErrorStatus.QUESTION_CHOICE_NOT_FOUND));
            return ExamConverter.toMemberAnswer(memberExam, question, questionChoice);
        }).toList();
        memberAnswerRepository.saveAll(memberAnswerList);
```
3. null 체크 부분을 분리하기 위해 지금의 코드가 됨