### PR TITLE
✨[FEAT] 오답노트 리스트 response 데이터 추가

### DIFF
--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -38,9 +38,10 @@ public class ExamConverter {
                 .build();
     }
 
-    public static ExamResponseDTO.GetExamResultDTO toGetExamResultDTO(int score, int questionNum,
+    public static ExamResponseDTO.GetExamResultDTO toGetExamResultDTO(long memberExamId, int score, int questionNum,
                                                                       int correctAnsNum, int incorrectAnsNum) {
         return ExamResponseDTO.GetExamResultDTO.builder()
+                .memberExamId(memberExamId)
                 .score(score)
                 .questionsNum(questionNum)
                 .correctAnsNum(correctAnsNum)

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -59,7 +59,7 @@ public class ExamConverter {
         return ExamResponseDTO.GetExamIncorrectAnswersResultDTO.builder()
                 .examIncorrectQuestionList(questions.stream().map(q ->
                         new ExamResponseDTO.GetExamIncorrectAnswersResultDTO.ExamIncorrectQuestion(
-                                q.getQuestionSequence(), q.getQuestionName()))
+                                q.getId(), q.getQuestionSequence(), q.getQuestionName()))
                         .toList()).build();
     }
 

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -10,7 +10,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
-    boolean existsByMemberIdAndExamId(Long memberId, Long examId);
     Optional<MemberExam> findByIdAndMemberAndStatus(Long memberExamId, Member member, Status status);
-    Optional<MemberExam> findFirstByMemberIdAndExamIdAndStatusOrderByCreatedAtDesc(Long memberId, Long examId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -2,6 +2,8 @@ package kr.co.teacherforboss.repository;
 
 import java.util.Optional;
 import java.util.List;
+
+import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.enums.Status;
 import org.springframework.data.domain.Sort;
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
+    Optional<MemberExam> findByIdAndMemberAndStatus(Long memberExamId, Member member, Status status);
     boolean existsByMemberIdAndExamId(Long memberId, Long examId);
     Optional<MemberExam> findByMemberIdAndExamIdAndStatus(Long memberId, Long examId, Status status);
 

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -1,6 +1,8 @@
 package kr.co.teacherforboss.repository;
 
 import java.util.Optional;
+
+import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +11,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
     boolean existsByMemberIdAndExamId(Long memberId, Long examId);
-
-    Optional<MemberExam> findByMemberIdAndExamIdAndStatus(Long memberId, Long examId, Status status);
+    Optional<MemberExam> findByIdAndMemberAndStatus(Long memberExamId, Member member, Status status);
+    Optional<MemberExam> findFirstByMemberIdAndExamIdAndStatusOrderByCreatedAtDesc(Long memberId, Long examId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandService.java
@@ -9,7 +9,7 @@ import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 public interface ExamCommandService {
     MemberExam takeExam(Long examId, ExamRequestDTO.TakeExamDTO request);
 
-    ExamResponseDTO.GetExamResultDTO getExamResult(Long examId);
+    ExamResponseDTO.GetExamResultDTO getExamResult(Long memberExamId);
 
     List<Question> getExamIncorrectAnswers(Long memberExamId);
 }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandService.java
@@ -11,5 +11,5 @@ public interface ExamCommandService {
 
     ExamResponseDTO.GetExamResultDTO getExamResult(Long examId);
 
-    List<Question> getExamIncorrectAnswers(Long examId);
+    List<Question> getExamIncorrectAnswers(Long memberExamId);
 }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
@@ -98,12 +98,12 @@ public class ExamCommandServiceImpl implements ExamCommandService {
         MemberExam memberExam = memberExamRepository.findByIdAndMemberAndStatus(memberExamId, member, Status.ACTIVE)
                 .orElseThrow(() -> new ExamHandler(ErrorStatus.MEMBER_EXAM_NOT_FOUND));
 
-        int questionsNum = questionRepository.countByExamIdAndStatus(memberExam.getExam().getId(), Status.ACTIVE);
+        int questionsNum =  memberExam.getExam().getQuestionList().size();
         int score = memberExam.getScore();
 
         List<MemberAnswer> memberAnswers = memberAnswerRepository.findAllByMemberExamIdAndStatus(memberExam.getId(), Status.ACTIVE);
         int correctAnsNum = memberAnswers.stream()
-                .filter(q -> q.getQuestion().getAnswer().equals(q.getQuestionChoice().getChoice())).mapToInt(e -> 1).sum();
+                .filter(q -> q.getQuestionChoice().isCorrect()).mapToInt(e -> 1).sum();
         int incorrectAnsNum = memberAnswers.size() - correctAnsNum;
 
         return ExamConverter.toGetExamResultDTO(memberExam.getId(), score, questionsNum, correctAnsNum, incorrectAnsNum);

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamCommandServiceImpl.java
@@ -92,16 +92,13 @@ public class ExamCommandServiceImpl implements ExamCommandService {
 
     @Override
     @Transactional(readOnly = true)
-    public ExamResponseDTO.GetExamResultDTO getExamResult(Long examId) {
+    public ExamResponseDTO.GetExamResultDTO getExamResult(Long memberExamId) {
         Member member = authCommandService.getMember();
 
-        if (!examRepository.existsByIdAndStatus(examId, Status.ACTIVE))
-            throw new ExamHandler(ErrorStatus.EXAM_NOT_FOUND);
-
-        MemberExam memberExam = memberExamRepository.findFirstByMemberIdAndExamIdAndStatusOrderByCreatedAtDesc(member.getId(), examId, Status.ACTIVE)
+        MemberExam memberExam = memberExamRepository.findByIdAndMemberAndStatus(memberExamId, member, Status.ACTIVE)
                 .orElseThrow(() -> new ExamHandler(ErrorStatus.MEMBER_EXAM_NOT_FOUND));
 
-        int questionsNum = questionRepository.countByExamIdAndStatus(examId, Status.ACTIVE);
+        int questionsNum = questionRepository.countByExamIdAndStatus(memberExam.getExam().getId(), Status.ACTIVE);
         int score = memberExam.getScore();
 
         List<MemberAnswer> memberAnswers = memberAnswerRepository.findAllByMemberExamIdAndStatus(memberExam.getId(), Status.ACTIVE);

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -48,9 +48,9 @@ public class ExamController {
         return ApiResponse.onSuccess(ExamConverter.toGetExamCategoriesDTO(examCategories));
     }
 
-    @GetMapping("/{examId}/result/incorrect/list")
-    public ApiResponse<ExamResponseDTO.GetExamIncorrectAnswersResultDTO> getExamIncorrectAnswers(@PathVariable("examId") Long examId) {
-        List<Question> questions = examCommandService.getExamIncorrectAnswers(examId);
+    @GetMapping("/{memberExamId}/result/incorrect/list")
+    public ApiResponse<ExamResponseDTO.GetExamIncorrectAnswersResultDTO> getExamIncorrectAnswers(@PathVariable("memberExamId") Long memberExamId) {
+        List<Question> questions = examCommandService.getExamIncorrectAnswers(memberExamId);
         return ApiResponse.onSuccess(ExamConverter.toGetExamAnsNotesDTO(questions));
     }
 

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -37,7 +37,7 @@ public class ExamController {
         return ApiResponse.onSuccess(ExamConverter.toTakeExamDTO(memberExam));
     }
 
-    @GetMapping("/{memberExamId}/result")
+    @GetMapping(" /member-exams/{memberExamId}/result")
     public ApiResponse<ExamResponseDTO.GetExamResultDTO> getExamResult(@PathVariable("memberExamId") Long memberExamId) {
         return ApiResponse.onSuccess(examCommandService.getExamResult(memberExamId));
     }

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -37,9 +37,9 @@ public class ExamController {
         return ApiResponse.onSuccess(ExamConverter.toTakeExamDTO(memberExam));
     }
 
-    @GetMapping("/{examId}/result")
-    public ApiResponse<ExamResponseDTO.GetExamResultDTO> getExamResult(@PathVariable("examId") Long examId) {
-        return ApiResponse.onSuccess(examCommandService.getExamResult(examId));
+    @GetMapping("/{memberExamId}/result")
+    public ApiResponse<ExamResponseDTO.GetExamResultDTO> getExamResult(@PathVariable("memberExamId") Long memberExamId) {
+        return ApiResponse.onSuccess(examCommandService.getExamResult(memberExamId));
     }
   
     @GetMapping("/category")
@@ -48,7 +48,7 @@ public class ExamController {
         return ApiResponse.onSuccess(ExamConverter.toGetExamCategoriesDTO(examCategories));
     }
 
-    @GetMapping("/{memberExamId}/result/incorrect/list")
+    @GetMapping("/member-exams/{memberExamId}/result/incorrect/list")
     public ApiResponse<ExamResponseDTO.GetExamIncorrectAnswersResultDTO> getExamIncorrectAnswers(@PathVariable("memberExamId") Long memberExamId) {
         List<Question> questions = examCommandService.getExamIncorrectAnswers(memberExamId);
         return ApiResponse.onSuccess(ExamConverter.toGetExamAnsNotesDTO(questions));

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
@@ -53,6 +53,7 @@ public class ExamResponseDTO {
         @Getter
         @AllArgsConstructor
         public static class ExamIncorrectQuestion {
+            Long questionId;
             int questionSequence;
             String questionName;
         }

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
@@ -22,6 +22,7 @@ public class ExamResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GetExamResultDTO{
+        long memberExamId;
         int score;
         int questionsNum;
         int correctAnsNum;


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #117 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/77263479/225a623f-4bac-4207-8269-337c7f305880)
![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/77263479/384c044e-fb17-43ec-89a1-9ed47d0f8c18)
- 재시험 보기 가능에 따라 시험 결과 조회시 최신순 정렬되어 top 1만 조회할 수 있도록 repository 메서드 수정
- 재시험 보기 가능에 따라 시험 저장 API response 값 변경
- 오답노트 조회 API path variable memberExamId로 수정
- 오답노트 조회 API response 값에 questionId 추가

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
