### PR TITLE
✨[FEAT] 같은 업종 사장님들 점수 API

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -85,6 +85,8 @@ public enum ErrorStatus implements BaseErrorCode {
     EXAM_NOT_FOUND(NOT_FOUND, "EXAM4042", "시험 정보를 찾을 수 없습니다."),
     QUESTION_NOT_FOUND(NOT_FOUND, "EXAM4043", "입력한 ID 값에 해당되는 문제를 찾을 수 없습니다."),
     QUESTION_CHOICE_NOT_FOUND(NOT_FOUND, "EXAM4044", "입력한 ID 값에 해당되는 문제 선지를 찾을 수 없습니다."),
+    EXAM_AVERAGE_NOT_FOUND(NOT_FOUND, "EXAM4045", "같은 업종 사장님 평균 점수를 내기 위한 데이터가 없습니다."),
+    MEMBER_EXAM_HISTORY_NOT_FOUND(NOT_FOUND, "EXAM4046", "사용자가 시험을 치룬 내역이 없습니다."),
 
 
     // For test

--- a/src/main/java/kr/co/teacherforboss/config/ExamConfig.java
+++ b/src/main/java/kr/co/teacherforboss/config/ExamConfig.java
@@ -1,5 +1,6 @@
 package kr.co.teacherforboss.config;
 
+import kr.co.teacherforboss.domain.enums.ExamQuarter;
 import kr.co.teacherforboss.domain.enums.ExamType;
 import lombok.Getter;
 import org.springframework.context.annotation.Configuration;
@@ -9,4 +10,5 @@ import org.springframework.context.annotation.Configuration;
 public class ExamConfig {
 
     public static final ExamType EXAM_TYPE = ExamType.MID;
+    public static final ExamQuarter EXAM_QUARTER = ExamQuarter.QUARTER2;
 }

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -97,4 +97,11 @@ public class ExamConverter {
                 .isMine(isMine)
                 .build();
     }
+
+    public static ExamResponseDTO.GetAverageDTO toGetAverageDTO(int averageScore, int userScore) {
+        return ExamResponseDTO.GetAverageDTO.builder()
+                .averageScore(averageScore)
+                .userScore(userScore)
+                .build();
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/domain/enums/ExamQuarter.java
+++ b/src/main/java/kr/co/teacherforboss/domain/enums/ExamQuarter.java
@@ -1,0 +1,16 @@
+package kr.co.teacherforboss.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExamQuarter {
+    QUARTER1(1, 3),
+    QUARTER2(4, 6),
+    QUARTER3(7, 9),
+    QUARTER4(10, 12);
+
+    private final int first;
+    private final int last;
+}

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -67,6 +67,7 @@ public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
 
     @Query(value = "select round(avg(me.score)) from member_exam me " +
             "where me.member_id <> :memberId " +
+            "and month(me.created_at) between :first and :last " +
             "and me.status = 'ACTIVE'", nativeQuery = true)
-    Optional<Integer> getAverageByMemberIdNot(@Param("memberId") Long memberId);
+    Optional<Integer> getAverageByMemberIdNot(@Param("memberId") Long memberId, @Param("first") int first, @Param("last") int last);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -61,8 +61,9 @@ public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
 
     @Query(value = "select round(avg(me.score)) from member_exam me " +
             "where me.member_id = :memberId " +
+            "and month(me.created_at) between :first and :last " +
             "and me.status = 'ACTIVE'", nativeQuery = true)
-    Optional<Integer> getAverageByMemberId(@Param("memberId") Long memberId);
+    Optional<Integer> getAverageByMemberId(@Param("memberId") Long memberId, @Param("first") int first, @Param("last") int last);
 
     @Query(value = "select round(avg(me.score)) from member_exam me " +
             "where me.member_id <> :memberId " +

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -62,10 +62,10 @@ public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
     @Query(value = "select round(avg(me.score)) from member_exam me " +
             "where me.member_id = :memberId " +
             "and me.status = 'ACTIVE'", nativeQuery = true)
-    Optional<Integer> findAllByMemberId(@Param("memberId") Long memberId);
+    Optional<Integer> getAverageByMemberId(@Param("memberId") Long memberId);
 
     @Query(value = "select round(avg(me.score)) from member_exam me " +
             "where me.member_id <> :memberId " +
             "and me.status = 'ACTIVE'", nativeQuery = true)
-    Optional<Integer> findByMemberIdNot(@Param("memberId") Long memberId);
+    Optional<Integer> getAverageByMemberIdNot(@Param("memberId") Long memberId);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -2,9 +2,9 @@ package kr.co.teacherforboss.repository;
 
 import java.util.Optional;
 import java.util.List;
+
 import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.enums.Status;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -57,4 +57,13 @@ public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
             + "where me1_0.id = :id", nativeQuery = true)
     Long findRankById(@Param("id") Long id);
 
+    @Query(value = "select round(avg(me.score)) from member_exam me " +
+            "where me.member_id = :memberId " +
+            "and me.status = 'ACTIVE'", nativeQuery = true)
+    Optional<Integer> findAllByMemberId(@Param("memberId") Long memberId);
+
+    @Query(value = "select round(avg(me.score)) from member_exam me " +
+            "where me.member_id <> :memberId " +
+            "and me.status = 'ACTIVE'", nativeQuery = true)
+    Optional<Integer> findByMemberIdNot(@Param("memberId") Long memberId);
 }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
@@ -3,6 +3,7 @@ package kr.co.teacherforboss.service.examService;
 import java.util.List;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.Question;
+import kr.co.teacherforboss.domain.enums.ExamQuarter;
 import kr.co.teacherforboss.domain.enums.ExamType;
 import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 
@@ -10,5 +11,5 @@ public interface ExamQueryService {
     List<ExamCategory> getExamCategories();
     List<Question> getQuestions(Long examId, ExamType examType);
     List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> getExamRankInfo(Long examId);
-    ExamResponseDTO.GetAverageDTO getAverage();
+    ExamResponseDTO.GetAverageDTO getAverage(ExamQuarter examQuarter);
 }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
@@ -10,4 +10,5 @@ public interface ExamQueryService {
     List<ExamCategory> getExamCategories();
     List<Question> getQuestions(Long examId, ExamType examType);
     List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> getExamRankInfo(Long examId);
+    ExamResponseDTO.GetAverageDTO getAverage();
 }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -91,9 +91,9 @@ public class ExamQueryServiceImpl implements ExamQueryService {
     public ExamResponseDTO.GetAverageDTO getAverage(){
         Member member = authCommandService.getMember();
 
-        Integer userScore = memberExamRepository.findAllByMemberId(member.getId())
+        Integer userScore = memberExamRepository.getAverageByMemberId(member.getId())
                 .orElseThrow(() -> new ExamHandler(ErrorStatus.MEMBER_EXAM_HISTORY_NOT_FOUND));
-        Integer averageScore = memberExamRepository.findByMemberIdNot(member.getId())
+        Integer averageScore = memberExamRepository.getAverageByMemberIdNot(member.getId())
                 .orElseThrow(() -> new ExamHandler(ErrorStatus.EXAM_AVERAGE_NOT_FOUND));
 
         return ExamConverter.toGetAverageDTO(averageScore, userScore);

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -10,6 +10,7 @@ import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.Question;
+import kr.co.teacherforboss.domain.enums.ExamQuarter;
 import kr.co.teacherforboss.domain.enums.ExamType;
 import kr.co.teacherforboss.domain.enums.Status;
 import kr.co.teacherforboss.repository.ExamCategoryRepository;
@@ -88,10 +89,10 @@ public class ExamQueryServiceImpl implements ExamQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public ExamResponseDTO.GetAverageDTO getAverage(){
+    public ExamResponseDTO.GetAverageDTO getAverage(ExamQuarter examQuarter){
         Member member = authCommandService.getMember();
 
-        Integer userScore = memberExamRepository.getAverageByMemberId(member.getId())
+        Integer userScore = memberExamRepository.getAverageByMemberId(member.getId(), examQuarter.getFirst(), examQuarter.getLast())
                 .orElseThrow(() -> new ExamHandler(ErrorStatus.MEMBER_EXAM_HISTORY_NOT_FOUND));
         Integer averageScore = memberExamRepository.getAverageByMemberIdNot(member.getId())
                 .orElseThrow(() -> new ExamHandler(ErrorStatus.EXAM_AVERAGE_NOT_FOUND));

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -95,7 +95,7 @@ public class ExamQueryServiceImpl implements ExamQueryService {
 
         Integer userScore = memberExamRepository.getAverageByMemberId(member.getId(), examQuarter.getFirst(), examQuarter.getLast())
                 .orElseThrow(() -> new ExamHandler(ErrorStatus.MEMBER_EXAM_HISTORY_NOT_FOUND));
-        Integer averageScore = memberExamRepository.getAverageByMemberIdNot(member.getId())
+        Integer averageScore = memberExamRepository.getAverageByMemberIdNot(member.getId(), examQuarter.getFirst(), examQuarter.getLast())
                 .orElseThrow(() -> new ExamHandler(ErrorStatus.EXAM_AVERAGE_NOT_FOUND));
 
         return ExamConverter.toGetAverageDTO(averageScore, userScore);

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -86,4 +86,17 @@ public class ExamQueryServiceImpl implements ExamQueryService {
         return examRankInfos;
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public ExamResponseDTO.GetAverageDTO getAverage(){
+        Member member = authCommandService.getMember();
+
+        Integer userScore = memberExamRepository.findAllByMemberId(member.getId())
+                .orElseThrow(() -> new ExamHandler(ErrorStatus.MEMBER_EXAM_HISTORY_NOT_FOUND));
+        Integer averageScore = memberExamRepository.findByMemberIdNot(member.getId())
+                .orElseThrow(() -> new ExamHandler(ErrorStatus.EXAM_AVERAGE_NOT_FOUND));
+
+        return ExamConverter.toGetAverageDTO(averageScore, userScore);
+    }
+
 }

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -65,4 +65,9 @@ public class ExamController {
         List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> rankInfos = examQueryService.getExamRankInfo(examId);
         return ApiResponse.onSuccess(ExamConverter.toGetExamRankInfoDTO(rankInfos));
     }
+
+    @GetMapping("/average")
+    public ApiResponse<ExamResponseDTO.GetAverageDTO> getAverage() {
+        return ApiResponse.onSuccess(examQueryService.getAverage());
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -68,6 +68,6 @@ public class ExamController {
 
     @GetMapping("/average")
     public ApiResponse<ExamResponseDTO.GetAverageDTO> getAverage() {
-        return ApiResponse.onSuccess(examQueryService.getAverage());
+        return ApiResponse.onSuccess(examQueryService.getAverage(ExamConfig.EXAM_QUARTER));
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
@@ -101,4 +101,13 @@ public class ExamResponseDTO {
             boolean isMine;
         }
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetAverageDTO{
+        int averageScore;
+        int userScore;
+    }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #123 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)
![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/77263479/d87b5226-1ac0-4bf0-8f16-b1ebb360c1aa)
- 네이티브 쿼리로 사용자 점수 평균 쿼리문, 같은 업종 사장님 점수 평균 쿼리문 작성

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
- 네이티브 쿼리로 round까지 점수 평균값 구하게 할지, 혹은 조건에 따른 memberExam 리스트만 조회한 뒤 평균을 구할지 고민입니다! 후자 고민하는 이유는 추후 repository 메서드문 재활용할 수 있을 거 같아서요..! 아예 지금처럼 쿼리문에서 평균 내버리는 게 날 거 같아 우선 네이티브 쿼리 작성했습니당
