### PR TITLE
✨[FEAT] 시험 치룬 횟수 조회 API

### DIFF
--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -98,4 +98,10 @@ public class ExamConverter {
                 .isMine(isMine)
                 .build();
     }
+
+    public static ExamResponseDTO.GetTakenExamCountDTO toGetTakenExamCountDTO(List<Exam> exams) {
+        return ExamResponseDTO.GetTakenExamCountDTO.builder()
+                .takenExamsCount(exams.size())
+                .build();
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/repository/ExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/ExamRepository.java
@@ -1,13 +1,20 @@
 package kr.co.teacherforboss.repository;
 
+import java.util.List;
 import java.util.Optional;
 import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ExamRepository extends JpaRepository<Exam, Long> {
     Optional<Exam> findByIdAndStatus(Long examId, Status status);
     boolean existsByIdAndStatus(Long id, Status status);
+
+    @Query(value = "select distinct e "
+            + "from Exam e, MemberExam me "
+            + "where e = me.exam")
+    List<Exam> findAllTakenExamByMemberId(Long memberId);
 }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
@@ -1,6 +1,7 @@
 package kr.co.teacherforboss.service.examService;
 
 import java.util.List;
+import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.Question;
 import kr.co.teacherforboss.domain.enums.ExamType;
@@ -10,4 +11,5 @@ public interface ExamQueryService {
     List<ExamCategory> getExamCategories();
     List<Question> getQuestions(Long examId, ExamType examType);
     List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> getExamRankInfo(Long examId);
+    List<Exam> getTakenExams();
 }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
 import kr.co.teacherforboss.apiPayload.exception.handler.ExamHandler;
 import kr.co.teacherforboss.converter.ExamConverter;
+import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.MemberExam;
@@ -84,6 +85,14 @@ public class ExamQueryServiceImpl implements ExamQueryService {
         }
 
         return examRankInfos;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Exam> getTakenExams() {
+        Member member = authCommandService.getMember();
+        List<Exam> exams = examRepository.findAllTakenExamByMemberId(member.getId());
+        return exams;
     }
 
 }

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import kr.co.teacherforboss.apiPayload.ApiResponse;
 import kr.co.teacherforboss.config.ExamConfig;
 import kr.co.teacherforboss.converter.ExamConverter;
+import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.Question;
@@ -64,5 +65,11 @@ public class ExamController {
     public ApiResponse<ExamResponseDTO.GetExamRankInfoDTO> getExamRankInfo(@PathVariable("examId") Long examId) {
         List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> rankInfos = examQueryService.getExamRankInfo(examId);
         return ApiResponse.onSuccess(ExamConverter.toGetExamRankInfoDTO(rankInfos));
+    }
+
+    @GetMapping("/count")
+    public ApiResponse<ExamResponseDTO.GetTakenExamCountDTO> getTakenExamCount() {
+        List<Exam> takenExams = examQueryService.getTakenExams();
+        return ApiResponse.onSuccess(ExamConverter.toGetTakenExamCountDTO(takenExams));
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
@@ -103,4 +103,12 @@ public class ExamResponseDTO {
             boolean isMine;
         }
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetTakenExamCountDTO {
+        int takenExamsCount;
+    }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #128 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

시험 치룬 횟수 조회하는 API 구현했습니다.
추후에 마이페이지 같은 곳에서 내가 본 시험 목록을 조회할 수도 있을 것같아 Exam list를 반환하는 서비스 함수로 작성하였습니다.

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
