### PR TITLE
✨[FEAT] 시험 태그 리스트 조회 API

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -86,6 +86,7 @@ public enum ErrorStatus implements BaseErrorCode {
     QUESTION_CHOICE_NOT_FOUND(NOT_FOUND, "EXAM4044", "입력한 ID 값에 해당되는 문제 선지를 찾을 수 없습니다."),
     EXAM_AVERAGE_NOT_FOUND(NOT_FOUND, "EXAM4045", "같은 업종 사장님 평균 점수를 내기 위한 데이터가 없습니다."),
     MEMBER_EXAM_HISTORY_NOT_FOUND(NOT_FOUND, "EXAM4046", "사용자가 시험을 치룬 내역이 없습니다."),
+    EXAM_CATEGORY_NOT_FOUND(NOT_FOUND, "EXAM4047", "시험 카테고리가 존재하지 않습니다."),
 
 
     // For test

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -57,17 +57,11 @@ public class ExamConverter {
                 .build();
     }
 
-    public static ExamResponseDTO.GetTagsDTO.TagInfo toGetTagInfo(Tag tag) {
-        return ExamResponseDTO.GetTagsDTO.TagInfo.builder()
-                .tagId(tag.getId())
-                .tagName(tag.getTagName())
-                .build();
-    }
-
-    public static ExamResponseDTO.GetTagsDTO toGetTagsDTO(List<ExamResponseDTO.GetTagsDTO.TagInfo> tagInfos) {
+    public static ExamResponseDTO.GetTagsDTO toGetTagsDTO(List<Tag> tags) {
         return ExamResponseDTO.GetTagsDTO.builder()
-                .tagsList(tagInfos)
-                .build();
+                .tagsList(tags.stream().map(tag ->
+                        new ExamResponseDTO.GetTagsDTO.TagInfo(tag.getId(), tag.getTagName()))
+                        .toList()).build();
     }
 
     public static ExamResponseDTO.GetExamIncorrectAnswersResultDTO toGetExamAnsNotesDTO(List<Question> questions) {

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -3,8 +3,6 @@ package kr.co.teacherforboss.converter;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.Member;
@@ -14,7 +12,6 @@ import kr.co.teacherforboss.domain.Question;
 import kr.co.teacherforboss.domain.QuestionChoice;
 import kr.co.teacherforboss.domain.Tag;
 import kr.co.teacherforboss.web.dto.ExamResponseDTO;
-import kr.co.teacherforboss.web.dto.ExamResponseDTO.TagInfo;
 
 public class ExamConverter {
 
@@ -60,20 +57,17 @@ public class ExamConverter {
                 .build();
     }
 
-    public static ExamResponseDTO.GetTagsDTO toGetTagsDTO(List<Tag> tags) {
-        Map<String, List<TagInfo>> categoryTagMap = tags.stream()
-                .collect(Collectors.groupingBy(
-                        tag -> tag.getExamCategory().getCategoryName(),
-                        Collectors.mapping(
-                                tag -> new TagInfo(tag.getId(), tag.getTagName()),
-                                Collectors.toList())
-                ));
+    public static ExamResponseDTO.GetTagsDTO.TagInfo toGetTagInfo(Tag tag) {
+        return ExamResponseDTO.GetTagsDTO.TagInfo.builder()
+                .tagId(tag.getId())
+                .tagName(tag.getTagName())
+                .build();
+    }
 
-        List<ExamResponseDTO.GetTagsDTO.CategoryTags> categoryTagsList = categoryTagMap.entrySet().stream()
-                .map(entry -> new ExamResponseDTO.GetTagsDTO.CategoryTags(entry.getKey(), entry.getValue()))
-                .collect(Collectors.toList());
-
-        return new ExamResponseDTO.GetTagsDTO(categoryTagsList);
+    public static ExamResponseDTO.GetTagsDTO toGetTagsDTO(List<ExamResponseDTO.GetTagsDTO.TagInfo> tagInfos) {
+        return ExamResponseDTO.GetTagsDTO.builder()
+                .tagsList(tagInfos)
+                .build();
     }
 
     public static ExamResponseDTO.GetExamIncorrectAnswersResultDTO toGetExamAnsNotesDTO(List<Question> questions) {
@@ -108,7 +102,7 @@ public class ExamConverter {
                         new ExamResponseDTO.GetSolutionsDTO.QuestionSolution(question.getId(), question.getCommentary()))
                         .toList()).build();
     }
-  
+
     public static ExamResponseDTO.GetExamRankInfoDTO toGetExamRankInfoDTO(List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> examRankInfos) {
         return ExamResponseDTO.GetExamRankInfoDTO.builder()
                 .examRankList(examRankInfos)

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -3,6 +3,8 @@ package kr.co.teacherforboss.converter;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.Member;
@@ -10,7 +12,9 @@ import kr.co.teacherforboss.domain.MemberAnswer;
 import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.Question;
 import kr.co.teacherforboss.domain.QuestionChoice;
+import kr.co.teacherforboss.domain.Tag;
 import kr.co.teacherforboss.web.dto.ExamResponseDTO;
+import kr.co.teacherforboss.web.dto.ExamResponseDTO.TagInfo;
 
 public class ExamConverter {
 
@@ -54,6 +58,22 @@ public class ExamConverter {
                 .examCategoryList(examCategories.stream().map(examCategory ->
                         new ExamResponseDTO.GetExamCategoriesDTO.ExamCategoryInfo(examCategory.getId(), examCategory.getCategoryName())).toList())
                 .build();
+    }
+
+    public static ExamResponseDTO.GetTagsDTO toGetTagsDTO(List<Tag> tags) {
+        Map<String, List<TagInfo>> categoryTagMap = tags.stream()
+                .collect(Collectors.groupingBy(
+                        tag -> tag.getExamCategory().getCategoryName(),
+                        Collectors.mapping(
+                                tag -> new TagInfo(tag.getId(), tag.getTagName()),
+                                Collectors.toList())
+                ));
+
+        List<ExamResponseDTO.GetTagsDTO.CategoryTags> categoryTagsList = categoryTagMap.entrySet().stream()
+                .map(entry -> new ExamResponseDTO.GetTagsDTO.CategoryTags(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+
+        return new ExamResponseDTO.GetTagsDTO(categoryTagsList);
     }
 
     public static ExamResponseDTO.GetExamIncorrectAnswersResultDTO toGetExamAnsNotesDTO(List<Question> questions) {

--- a/src/main/java/kr/co/teacherforboss/domain/Exam.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Exam.java
@@ -31,8 +31,8 @@ public class Exam extends BaseEntity {
     private ExamCategory examCategory;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "examSubCategoryId")
-    private ExamSubCategory examSubCategory;
+    @JoinColumn(name = "tagId")
+    private Tag tag;
 
     @NotNull
     @Column(length = 60)

--- a/src/main/java/kr/co/teacherforboss/domain/Exam.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Exam.java
@@ -30,6 +30,14 @@ public class Exam extends BaseEntity {
     @JoinColumn(name = "examCategoryId")
     private ExamCategory examCategory;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "examSubCategoryId")
+    private ExamSubCategory examSubCategory;
+
+    @NotNull
+    @Column(length = 60)
+    private String detail;
+
     @NotNull
     @Column(length = 30)
     private String name;

--- a/src/main/java/kr/co/teacherforboss/domain/Exam.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Exam.java
@@ -36,7 +36,7 @@ public class Exam extends BaseEntity {
 
     @NotNull
     @Column(length = 60)
-    private String detail;
+    private String description;
 
     @NotNull
     @Column(length = 30)

--- a/src/main/java/kr/co/teacherforboss/domain/ExamCategory.java
+++ b/src/main/java/kr/co/teacherforboss/domain/ExamCategory.java
@@ -20,5 +20,4 @@ public class ExamCategory extends BaseEntity {
     @NotNull
     @Column(length = 10)
     private String categoryName;
-
 }

--- a/src/main/java/kr/co/teacherforboss/domain/ExamSubCategory.java
+++ b/src/main/java/kr/co/teacherforboss/domain/ExamSubCategory.java
@@ -1,0 +1,23 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.validation.constraints.NotNull;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ExamSubCategory extends BaseEntity {
+
+    @NotNull
+    @Column(length = 10)
+    private String subCategoryName;
+}

--- a/src/main/java/kr/co/teacherforboss/domain/Tag.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Tag.java
@@ -2,6 +2,9 @@ package kr.co.teacherforboss.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import kr.co.teacherforboss.domain.common.BaseEntity;
 import lombok.AccessLevel;
@@ -20,4 +23,8 @@ public class Tag extends BaseEntity {
     @NotNull
     @Column(length = 10)
     private String tagName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "examCategoryId")
+    private ExamCategory examCategory;
 }

--- a/src/main/java/kr/co/teacherforboss/domain/Tag.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Tag.java
@@ -15,9 +15,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class ExamSubCategory extends BaseEntity {
+public class Tag extends BaseEntity {
 
     @NotNull
     @Column(length = 10)
-    private String subCategoryName;
+    private String tagName;
 }

--- a/src/main/java/kr/co/teacherforboss/repository/ExamCategoryRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/ExamCategoryRepository.java
@@ -8,5 +8,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ExamCategoryRepository extends JpaRepository<ExamCategory, Long> {
+
+    boolean existsByIdAndStatus(Long id, Status status);
     List<ExamCategory> findExamCategoriesByStatus(Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/TagRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/TagRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 
 @Repository
 public interface TagRepository extends JpaRepository<Tag, Long> {
-    List<Tag> findTagsByStatus(Status status);
+    List<Tag> findTagsByExamCategoryIdAndStatus(Long categoryId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/TagRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/TagRepository.java
@@ -1,0 +1,13 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.Tag;
+import kr.co.teacherforboss.domain.enums.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    List<Tag> findTagsByStatus(Status status);
+}

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
@@ -5,12 +5,13 @@ import java.util.List;
 import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.Question;
+import kr.co.teacherforboss.domain.Tag;
 import kr.co.teacherforboss.domain.enums.ExamQuarter;
 import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 
 public interface ExamQueryService {
     List<ExamCategory> getExamCategories();
-    List<ExamResponseDTO.GetTagsDTO.TagInfo> getTags(Long categoryId);
+    List<Tag> getTags(Long categoryId);
     List<Question> getQuestions(Long examId);
     List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> getExamRankInfo(Long examId);
     ExamResponseDTO.GetAverageDTO getAverage(ExamQuarter examQuarter);

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
@@ -5,14 +5,12 @@ import java.util.List;
 import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.Question;
-import kr.co.teacherforboss.domain.Tag;
 import kr.co.teacherforboss.domain.enums.ExamQuarter;
-import kr.co.teacherforboss.domain.enums.ExamType;
 import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 
 public interface ExamQueryService {
     List<ExamCategory> getExamCategories();
-    List<Tag> getTags(Long categoryId);
+    List<ExamResponseDTO.GetTagsDTO.TagInfo> getTags(Long categoryId);
     List<Question> getQuestions(Long examId);
     List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> getExamRankInfo(Long examId);
     ExamResponseDTO.GetAverageDTO getAverage(ExamQuarter examQuarter);

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
@@ -12,7 +12,7 @@ import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 
 public interface ExamQueryService {
     List<ExamCategory> getExamCategories();
-    List<Tag> getTags();
+    List<Tag> getTags(Long categoryId);
     List<Question> getQuestions(Long examId);
     List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> getExamRankInfo(Long examId);
     ExamResponseDTO.GetAverageDTO getAverage(ExamQuarter examQuarter);

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
@@ -1,9 +1,12 @@
 package kr.co.teacherforboss.service.examService;
 
 import java.util.List;
+
+import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.Question;
 import kr.co.teacherforboss.domain.Tag;
+import kr.co.teacherforboss.domain.enums.ExamQuarter;
 import kr.co.teacherforboss.domain.enums.ExamType;
 import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 
@@ -12,4 +15,6 @@ public interface ExamQueryService {
     List<Tag> getTags();
     List<Question> getQuestions(Long examId, ExamType examType);
     List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> getExamRankInfo(Long examId);
+    ExamResponseDTO.GetAverageDTO getAverage(ExamQuarter examQuarter);
+    List<Exam> getTakenExams();
 }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
@@ -13,7 +13,7 @@ import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 public interface ExamQueryService {
     List<ExamCategory> getExamCategories();
     List<Tag> getTags();
-    List<Question> getQuestions(Long examId, ExamType examType);
+    List<Question> getQuestions(Long examId);
     List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> getExamRankInfo(Long examId);
     ExamResponseDTO.GetAverageDTO getAverage(ExamQuarter examQuarter);
     List<Exam> getTakenExams();

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
@@ -3,11 +3,13 @@ package kr.co.teacherforboss.service.examService;
 import java.util.List;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.Question;
+import kr.co.teacherforboss.domain.Tag;
 import kr.co.teacherforboss.domain.enums.ExamType;
 import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 
 public interface ExamQueryService {
     List<ExamCategory> getExamCategories();
+    List<Tag> getTags();
     List<Question> getQuestions(Long examId, ExamType examType);
     List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> getExamRankInfo(Long examId);
 }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -45,16 +45,11 @@ public class ExamQueryServiceImpl implements ExamQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<ExamResponseDTO.GetTagsDTO.TagInfo> getTags(Long examCategoryId) {
-        List<Tag> tagList = tagRepository.findTagsByExamCategoryIdAndStatus(examCategoryId, Status.ACTIVE);
-        List<ExamResponseDTO.GetTagsDTO.TagInfo> tagInfos = new ArrayList<>();
+    public List<Tag> getTags(Long examCategoryId) {
+        if (!examCategoryRepository.existsByIdAndStatus(examCategoryId, Status.ACTIVE))
+            throw new ExamHandler(ErrorStatus.EXAM_CATEGORY_NOT_FOUND);
 
-        for (Tag tag : tagList) {
-            ExamResponseDTO.GetTagsDTO.TagInfo tagInfo = ExamConverter.toGetTagInfo(tag);
-            tagInfos.add(tagInfo);
-        }
-
-        return tagInfos;
+        return tagRepository.findTagsByExamCategoryIdAndStatus(examCategoryId, Status.ACTIVE);
     }
 
     @Override

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -10,12 +10,14 @@ import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.Question;
+import kr.co.teacherforboss.domain.Tag;
 import kr.co.teacherforboss.domain.enums.ExamType;
 import kr.co.teacherforboss.domain.enums.Status;
 import kr.co.teacherforboss.repository.ExamCategoryRepository;
 import kr.co.teacherforboss.repository.ExamRepository;
 import kr.co.teacherforboss.repository.MemberExamRepository;
 import kr.co.teacherforboss.repository.QuestionRepository;
+import kr.co.teacherforboss.repository.TagRepository;
 import kr.co.teacherforboss.service.authService.AuthCommandService;
 import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -32,11 +34,18 @@ public class ExamQueryServiceImpl implements ExamQueryService {
     private final QuestionRepository questionRepository;
     private final MemberExamRepository memberExamRepository;
     private final AuthCommandService authCommandService;
+    private final TagRepository tagRepository;
 
     @Override
     @Transactional(readOnly = true)
     public List<ExamCategory> getExamCategories() {
         return examCategoryRepository.findExamCategoriesByStatus(Status.ACTIVE);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Tag> getTags() {
+        return tagRepository.findTagsByStatus(Status.ACTIVE);
     }
 
     @Override

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -6,11 +6,13 @@ import java.util.Objects;
 import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
 import kr.co.teacherforboss.apiPayload.exception.handler.ExamHandler;
 import kr.co.teacherforboss.converter.ExamConverter;
+import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.Question;
 import kr.co.teacherforboss.domain.Tag;
+import kr.co.teacherforboss.domain.enums.ExamQuarter;
 import kr.co.teacherforboss.domain.enums.ExamType;
 import kr.co.teacherforboss.domain.enums.Status;
 import kr.co.teacherforboss.repository.ExamCategoryRepository;
@@ -95,4 +97,24 @@ public class ExamQueryServiceImpl implements ExamQueryService {
         return examRankInfos;
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public ExamResponseDTO.GetAverageDTO getAverage(ExamQuarter examQuarter){
+        Member member = authCommandService.getMember();
+
+        Integer userScore = memberExamRepository.getAverageByMemberId(member.getId(), examQuarter.getFirst(), examQuarter.getLast())
+                .orElseThrow(() -> new ExamHandler(ErrorStatus.MEMBER_EXAM_HISTORY_NOT_FOUND));
+        Integer averageScore = memberExamRepository.getAverageByMemberIdNot(member.getId(), examQuarter.getFirst(), examQuarter.getLast())
+                .orElseThrow(() -> new ExamHandler(ErrorStatus.EXAM_AVERAGE_NOT_FOUND));
+
+        return ExamConverter.toGetAverageDTO(averageScore, userScore);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Exam> getTakenExams() {
+        Member member = authCommandService.getMember();
+        List<Exam> exams = examRepository.findAllTakenExamByMemberId(member.getId());
+        return exams;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -46,8 +46,8 @@ public class ExamQueryServiceImpl implements ExamQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<Tag> getTags() {
-        return tagRepository.findTagsByStatus(Status.ACTIVE);
+    public List<Tag> getTags(Long examCategoryId) {
+        return tagRepository.findTagsByExamCategoryIdAndStatus(examCategoryId, Status.ACTIVE);
     }
 
     @Override

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -52,7 +52,7 @@ public class ExamQueryServiceImpl implements ExamQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<Question> getQuestions(Long examId, ExamType examType) {
+    public List<Question> getQuestions(Long examId) {
         if (!examRepository.existsByIdAndStatus(examId, Status.ACTIVE))
             throw new ExamHandler(ErrorStatus.EXAM_NOT_FOUND);
 

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -13,7 +13,6 @@ import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.Question;
 import kr.co.teacherforboss.domain.Tag;
 import kr.co.teacherforboss.domain.enums.ExamQuarter;
-import kr.co.teacherforboss.domain.enums.ExamType;
 import kr.co.teacherforboss.domain.enums.Status;
 import kr.co.teacherforboss.repository.ExamCategoryRepository;
 import kr.co.teacherforboss.repository.ExamRepository;
@@ -46,8 +45,16 @@ public class ExamQueryServiceImpl implements ExamQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<Tag> getTags(Long examCategoryId) {
-        return tagRepository.findTagsByExamCategoryIdAndStatus(examCategoryId, Status.ACTIVE);
+    public List<ExamResponseDTO.GetTagsDTO.TagInfo> getTags(Long examCategoryId) {
+        List<Tag> tagList = tagRepository.findTagsByExamCategoryIdAndStatus(examCategoryId, Status.ACTIVE);
+        List<ExamResponseDTO.GetTagsDTO.TagInfo> tagInfos = new ArrayList<>();
+
+        for (Tag tag : tagList) {
+            ExamResponseDTO.GetTagsDTO.TagInfo tagInfo = ExamConverter.toGetTagInfo(tag);
+            tagInfos.add(tagInfo);
+        }
+
+        return tagInfos;
     }
 
     @Override

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -8,6 +8,7 @@ import kr.co.teacherforboss.converter.ExamConverter;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.Question;
+import kr.co.teacherforboss.domain.Tag;
 import kr.co.teacherforboss.service.examService.ExamCommandService;
 import kr.co.teacherforboss.service.examService.ExamQueryService;
 import kr.co.teacherforboss.web.dto.ExamRequestDTO;
@@ -46,6 +47,12 @@ public class ExamController {
     public ApiResponse<ExamResponseDTO.GetExamCategoriesDTO> getExamCategories() {
         List<ExamCategory> examCategories = examQueryService.getExamCategories();
         return ApiResponse.onSuccess(ExamConverter.toGetExamCategoriesDTO(examCategories));
+    }
+
+    @GetMapping("/category/tags")
+    public ApiResponse<ExamResponseDTO.GetTagsDTO> getTags() {
+        List<Tag> tags = examQueryService.getTags();
+        return ApiResponse.onSuccess(ExamConverter.toGetTagsDTO(tags));
     }
 
     @GetMapping("/member-exams/{memberExamId}/result/incorrect/list")

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -9,6 +9,7 @@ import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.Question;
+import kr.co.teacherforboss.domain.Tag;
 import kr.co.teacherforboss.service.examService.ExamCommandService;
 import kr.co.teacherforboss.service.examService.ExamQueryService;
 import kr.co.teacherforboss.web.dto.ExamRequestDTO;
@@ -51,8 +52,8 @@ public class ExamController {
 
     @GetMapping("/{examCategoryId}/tags")
     public ApiResponse<ExamResponseDTO.GetTagsDTO> getTags(@PathVariable("examCategoryId") Long examCategoryId) {
-        List<ExamResponseDTO.GetTagsDTO.TagInfo> tagInfos = examQueryService.getTags(examCategoryId);
-        return ApiResponse.onSuccess(ExamConverter.toGetTagsDTO(tagInfos));
+        List<Tag> tags = examQueryService.getTags(examCategoryId);
+        return ApiResponse.onSuccess(ExamConverter.toGetTagsDTO(tags));
     }
 
     @GetMapping("/member-exams/{memberExamId}/result/incorrect/list")

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -9,7 +9,6 @@ import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.Question;
-import kr.co.teacherforboss.domain.Tag;
 import kr.co.teacherforboss.service.examService.ExamCommandService;
 import kr.co.teacherforboss.service.examService.ExamQueryService;
 import kr.co.teacherforboss.web.dto.ExamRequestDTO;
@@ -52,8 +51,8 @@ public class ExamController {
 
     @GetMapping("/{examCategoryId}/tags")
     public ApiResponse<ExamResponseDTO.GetTagsDTO> getTags(@PathVariable("examCategoryId") Long examCategoryId) {
-        List<Tag> tags = examQueryService.getTags(examCategoryId);
-        return ApiResponse.onSuccess(ExamConverter.toGetTagsDTO(tags));
+        List<ExamResponseDTO.GetTagsDTO.TagInfo> tagInfos = examQueryService.getTags(examCategoryId);
+        return ApiResponse.onSuccess(ExamConverter.toGetTagsDTO(tagInfos));
     }
 
     @GetMapping("/member-exams/{memberExamId}/result/incorrect/list")

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -50,15 +50,10 @@ public class ExamController {
         return ApiResponse.onSuccess(ExamConverter.toGetExamCategoriesDTO(examCategories));
     }
 
-    @GetMapping("/category/tags")
-    public ApiResponse<ExamResponseDTO.GetTagsDTO> getTags() {
-        List<Tag> tags = examQueryService.getTags();
+    @GetMapping("/{examCategoryId}/tags")
+    public ApiResponse<ExamResponseDTO.GetTagsDTO> getTags(@PathVariable("examCategoryId") Long examCategoryId) {
+        List<Tag> tags = examQueryService.getTags(examCategoryId);
         return ApiResponse.onSuccess(ExamConverter.toGetTagsDTO(tags));
-    }
-
-    @GetMapping("/list/{categoryId}/{tagId}")
-    public void getExams() {
-        return;
     }
 
     @GetMapping("/member-exams/{memberExamId}/result/incorrect/list")

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
@@ -44,6 +44,28 @@ public class ExamResponseDTO {
         }
     }
 
+    @Getter
+    @AllArgsConstructor
+    public static class TagInfo {
+        private Long tagId;
+        private String tagName;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetTagsDTO {
+        private List<CategoryTags> tagsList;
+
+        @Getter
+        @AllArgsConstructor
+        public static class CategoryTags {
+            private String categoryName;
+            private List<TagInfo> tagsInfo;
+        }
+    }
+
     @Builder
     @Getter
     @NoArgsConstructor

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
@@ -44,25 +44,19 @@ public class ExamResponseDTO {
         }
     }
 
-    @Getter
-    @AllArgsConstructor
-    public static class TagInfo {
-        private Long tagId;
-        private String tagName;
-    }
-
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GetTagsDTO {
-        private List<CategoryTags> tagsList;
+        private List<TagInfo> tagsList;
 
+        @Builder
         @Getter
         @AllArgsConstructor
-        public static class CategoryTags {
-            private String categoryName;
-            private List<TagInfo> tagsInfo;
+        public static class TagInfo {
+            private Long tagId;
+            private String tagName;
         }
     }
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #125 

## 📝 작업 내용

시험 태그 (= 시험 세부 카테고리) 리스트 조회

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

**Postman 테스트**
![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/113760409/4050474d-c2bc-447a-9ef7-4a77978dc774)
![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/113760409/f2e475b0-1d71-4a3b-b80f-09c81635e4d8)



일단 uri가 exams/category/tags 라서 
따로 category값을 PathVariable로 설정하진 않았는데,
지금 구현한 방식으로 전체 category의 tag값을 조회하도록 하면 될까요?

그러니까,

1) exams/{categoryId}/tags 로 해서 각 카테고리 마다 tag 리스트를 조회하게 할지
2) exams/category/tags로 하고 그냥 전체 카테고리와 해당 카테고리의 tag 리스트를 조회하게 할지

위 두 방식 중에 우선은 2번처럼 구현을 한 상태인데, 1번처럼 하지 않는게 맞나요?!
(저는 피그마에서 각 카테고리 별로 보여야 하는 tag가 다르니까.. 1번 방식처럼 구현하는게 프론트 입장에선 더 편하지 않을까 생각하긴 했는데, 두 방식 중 어떤식으로 구현해야 좋을지..! 여러분들 의견이 궁금합니댜)
