### PR TITLE
✨[FEAT] 시험 리스트 조회 API

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -87,8 +87,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EXAM_AVERAGE_NOT_FOUND(NOT_FOUND, "EXAM4045", "같은 업종 사장님 평균 점수를 내기 위한 데이터가 없습니다."),
     MEMBER_EXAM_HISTORY_NOT_FOUND(NOT_FOUND, "EXAM4046", "사용자가 시험을 치룬 내역이 없습니다."),
     EXAM_CATEGORY_NOT_FOUND(NOT_FOUND, "EXAM4047", "시험 카테고리가 존재하지 않습니다."),
-    EXAM_TAG_NOT_FOUND(NOT_FOUND, "EXAM4048", "시험 태그가 존재하지 않습니다."),
-
+    EXAM_TAG_NOT_FOUND(NOT_FOUND, "EXAM4048", "시험 카테고리가 존재하지 않습니다."),
 
     // For test
     TEMP_EXCEPTION(BAD_REQUEST, "TEMP4001", "이거는 테스트");

--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -87,6 +87,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EXAM_AVERAGE_NOT_FOUND(NOT_FOUND, "EXAM4045", "같은 업종 사장님 평균 점수를 내기 위한 데이터가 없습니다."),
     MEMBER_EXAM_HISTORY_NOT_FOUND(NOT_FOUND, "EXAM4046", "사용자가 시험을 치룬 내역이 없습니다."),
     EXAM_CATEGORY_NOT_FOUND(NOT_FOUND, "EXAM4047", "시험 카테고리가 존재하지 않습니다."),
+    EXAM_TAG_NOT_FOUND(NOT_FOUND, "EXAM4048", "시험 태그가 존재하지 않습니다."),
 
 
     // For test

--- a/src/main/java/kr/co/teacherforboss/config/ExamConfig.java
+++ b/src/main/java/kr/co/teacherforboss/config/ExamConfig.java
@@ -11,5 +11,5 @@ public class ExamConfig {
 
     public static final ExamType EXAM_TYPE = ExamType.MID;
     public static final ExamQuarter EXAM_QUARTER = ExamQuarter.QUARTER2;
-    public static final Integer PATH_THRESHOLD = 70;
+    public static final Integer PASS_THRESHOLD = 70;
 }

--- a/src/main/java/kr/co/teacherforboss/config/ExamConfig.java
+++ b/src/main/java/kr/co/teacherforboss/config/ExamConfig.java
@@ -11,4 +11,5 @@ public class ExamConfig {
 
     public static final ExamType EXAM_TYPE = ExamType.MID;
     public static final ExamQuarter EXAM_QUARTER = ExamQuarter.QUARTER2;
+    public static final Integer PATH_THRESHOLD = 70;
 }

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -2,7 +2,10 @@ package kr.co.teacherforboss.converter;
 
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+
+import kr.co.teacherforboss.config.ExamConfig;
 import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.Member;
@@ -64,7 +67,24 @@ public class ExamConverter {
                         .toList()).build();
     }
 
-    public static ExamResponseDTO.GetExamsDTO toGetExamsDTO(List<ExamResponseDTO.GetExamsDTO.ExamInfo> examInfos) {
+    public static ExamResponseDTO.GetExamsDTO toGetExamsDTO(List<Exam> examList, List<MemberExam> memberExamList) {
+        List<ExamResponseDTO.GetExamsDTO.ExamInfo> examInfos = new ArrayList<>();
+
+        for (Exam exam : examList) {
+            boolean isTakenExam = false;
+            Integer score = null;
+            boolean isPassed = false;
+
+            for (MemberExam memberExam : memberExamList) {
+                isTakenExam = memberExam != null;
+                score = isTakenExam ? memberExam.getScore() : null;
+                isPassed = isTakenExam && score >= ExamConfig.PATH_THRESHOLD;
+            }
+
+            ExamResponseDTO.GetExamsDTO.ExamInfo examInfo = toGetExamInfo(exam, isTakenExam, isPassed, score);
+            examInfos.add(examInfo);
+        }
+
         return ExamResponseDTO.GetExamsDTO.builder()
                 .examList(examInfos)
                 .build();

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -84,13 +84,13 @@ public class ExamConverter {
 
     public static ExamResponseDTO.GetExamsDTO.ExamInfo toGetExamInfo(Exam exam, boolean isTakenExam, Boolean isPassed, Integer score) {
         return ExamResponseDTO.GetExamsDTO.ExamInfo.builder()
-                .name(exam.getName())
-                .description(exam.getDescription())
+                .examId(exam.getId())
+                .examName(exam.getName())
+                .examDescription(exam.getDescription())
                 .tagName(exam.getTag().getTagName())
-                .examCategoryName(exam.getExamCategory().getCategoryName())
-                .isTakenExam(isTakenExam)
-                .isPassed(isPassed)
-                .score(score)
+                .examYN(isTakenExam)
+                .examPassYN(isPassed)
+                .examScore(score)
                 .build();
     }
 

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -78,7 +78,7 @@ public class ExamConverter {
             for (MemberExam memberExam : memberExamList) {
                 isTakenExam = memberExam != null;
                 score = isTakenExam ? memberExam.getScore() : null;
-                isPassed = isTakenExam && score >= ExamConfig.PATH_THRESHOLD;
+                isPassed = isTakenExam && score >= ExamConfig.PASS_THRESHOLD;
             }
 
             ExamResponseDTO.GetExamsDTO.ExamInfo examInfo = toGetExamInfo(exam, isTakenExam, isPassed, score);

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -87,13 +87,13 @@ public class ExamConverter {
 
     public static ExamResponseDTO.GetExamsDTO.ExamInfo toGetExamInfo(Exam exam, boolean isTakenExam, Boolean isPassed, Integer score) {
         return ExamResponseDTO.GetExamsDTO.ExamInfo.builder()
-                .examId(exam.getId())
-                .tagName(exam.getTag().getTagName())
-                .examName(exam.getName())
-                .examDescription(exam.getDescription())
-                .examYN(isTakenExam)
-                .examPassYN(isPassed)
-                .examScore(score)
+                .id(exam.getId())
+                .tag(exam.getTag().getTagName())
+                .name(exam.getName())
+                .description(exam.getDescription())
+                .isTaken(isTakenExam)
+                .isPassed(isPassed)
+                .score(score)
                 .build();
     }
 

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -73,6 +73,7 @@ public class ExamConverter {
     public static ExamResponseDTO.GetExamsDTO.ExamInfo toGetExamInfo(Exam exam, boolean isTakenExam, Boolean isPassed, Integer score) {
         return ExamResponseDTO.GetExamsDTO.ExamInfo.builder()
                 .examId(exam.getId())
+                .tagName(exam.getTag().getTagName())
                 .examName(exam.getName())
                 .examDescription(exam.getDescription())
                 .examYN(isTakenExam)

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -76,6 +76,24 @@ public class ExamConverter {
         return new ExamResponseDTO.GetTagsDTO(categoryTagsList);
     }
 
+    public static ExamResponseDTO.GetExamsDTO toGetExamsDTO(List<ExamResponseDTO.GetExamsDTO.ExamInfo> examInfos) {
+        return ExamResponseDTO.GetExamsDTO.builder()
+                .examList(examInfos)
+                .build();
+    }
+
+    public static ExamResponseDTO.GetExamsDTO.ExamInfo toGetExamInfo(Exam exam, boolean isTakenExam, Boolean isPassed, Integer score) {
+        return ExamResponseDTO.GetExamsDTO.ExamInfo.builder()
+                .name(exam.getName())
+                .description(exam.getDescription())
+                .tagName(exam.getTag().getTagName())
+                .examCategoryName(exam.getExamCategory().getCategoryName())
+                .isTakenExam(isTakenExam)
+                .isPassed(isPassed)
+                .score(score)
+                .build();
+    }
+
     public static ExamResponseDTO.GetExamIncorrectAnswersResultDTO toGetExamAnsNotesDTO(List<Question> questions) {
         return ExamResponseDTO.GetExamIncorrectAnswersResultDTO.builder()
                 .examIncorrectQuestionList(questions.stream().map(q ->

--- a/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/ExamConverter.java
@@ -75,7 +75,6 @@ public class ExamConverter {
                 .examId(exam.getId())
                 .examName(exam.getName())
                 .examDescription(exam.getDescription())
-                .tagName(exam.getTag().getTagName())
                 .examYN(isTakenExam)
                 .examPassYN(isPassed)
                 .examScore(score)

--- a/src/main/java/kr/co/teacherforboss/repository/ExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/ExamRepository.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ExamRepository extends JpaRepository<Exam, Long> {
+    List<Exam> findByExamCategoryIdAndStatus(Long examCategoryId, Status status);
     List<Exam> findByExamCategoryIdAndTagIdAndStatus(Long examCategoryId, Long TagId, Status status);
     Optional<Exam> findByIdAndStatus(Long examId, Status status);
     boolean existsByIdAndStatus(Long id, Status status);

--- a/src/main/java/kr/co/teacherforboss/repository/ExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/ExamRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ExamRepository extends JpaRepository<Exam, Long> {
     List<Exam> findByExamCategoryIdAndStatus(Long examCategoryId, Status status);
-    List<Exam> findByExamCategoryIdAndTagIdAndStatus(Long examCategoryId, Long TagId, Status status);
+    List<Exam> findByExamCategoryIdAndTagIdAndStatus(Long examCategoryId, Long tagId, Status status);
     Optional<Exam> findByIdAndStatus(Long examId, Status status);
     boolean existsByIdAndStatus(Long id, Status status);
 

--- a/src/main/java/kr/co/teacherforboss/repository/ExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/ExamRepository.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ExamRepository extends JpaRepository<Exam, Long> {
+    List<Exam> findByExamCategoryIdAndTagIdAndStatus(Long examCategoryId, Long TagId, Status status);
     Optional<Exam> findByIdAndStatus(Long examId, Status status);
     boolean existsByIdAndStatus(Long id, Status status);
 

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -15,18 +15,18 @@ import org.springframework.stereotype.Repository;
 public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
     @Query(value = "select me.* "
             + "from member_exam me "
-            + "inner join exam e on me.exam_id = e.id "
-            + "inner join (select e1.exam_category_id, e1.tag_id, max(me1.updated_at) as max_updated_at "
-            + "            from member_exam me1 "
-            + "            inner join exam e1 on me1.exam_id = e1.id "
-            + "            where me1.member_id = :memberId and me1.status = 'ACTIVE' "
-            + "            group by e1.exam_category_id, e1.tag_id) as latest "
-            + "on e.exam_category_id = latest.exam_category_id "
-            + "and e.tag_id = latest.tag_id "
-            + "and me.updated_at = latest.max_updated_at " 
+            + "inner join ( "
+            + "    select exam_id, MAX(created_at) as created_at "
+            + "    from member_exam "
+            + "    where member_id = :memberId "
+            + "    group by exam_id"
+            + "            ) latest "
             + "where me.member_id = :memberId "
+            + "and me.exam_id = latest.exam_id  "
+            + "and me.created_at = latest.created_at "
             + "and me.status = 'ACTIVE'", nativeQuery = true)
     List<MemberExam> findRecentByMemberIdGroupByCategoryAndTag(@Param("memberId") Long memberId);
+
     Optional<MemberExam> findByIdAndMemberAndStatus(Long memberExamId, Member member, Status status);
     boolean existsByMemberIdAndExamId(Long memberId, Long examId);
 

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -13,9 +13,10 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
+
     Optional<MemberExam> findByIdAndMemberAndStatus(Long memberExamId, Member member, Status status);
     boolean existsByMemberIdAndExamId(Long memberId, Long examId);
-    Optional<MemberExam> findByMemberIdAndExamIdAndStatus(Long memberId, Long examId, Status status);
+    MemberExam findByMemberIdAndExamIdAndStatus(Long memberId, Long examId, Status status);
 
     @Query(value = "select *"
             + "from member_exam me "

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -14,18 +14,17 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
     @Query(value = "select me.* "
-            + "from member_exam me "
-            + "inner join ( "
-            + "    select exam_id, MAX(created_at) as created_at "
+            + "from member_exam me, "
+            + "    (select exam_id, MAX(created_at) as created_at "
             + "    from member_exam "
             + "    where member_id = :memberId "
             + "    group by exam_id"
-            + "            ) latest "
+            + "     ) as latest "
             + "where me.member_id = :memberId "
             + "and me.exam_id = latest.exam_id  "
             + "and me.created_at = latest.created_at "
             + "and me.status = 'ACTIVE'", nativeQuery = true)
-    List<MemberExam> findRecentByMemberIdGroupByCategoryAndTag(@Param("memberId") Long memberId);
+    List<MemberExam> findAllRecentByMemberId(@Param("memberId") Long memberId);
 
     Optional<MemberExam> findByIdAndMemberAndStatus(Long memberExamId, Member member, Status status);
     boolean existsByMemberIdAndExamId(Long memberId, Long examId);

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -13,10 +13,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
-
+    List<MemberExam> findByMemberAndStatus(Member member, Status status);
     Optional<MemberExam> findByIdAndMemberAndStatus(Long memberExamId, Member member, Status status);
     boolean existsByMemberIdAndExamId(Long memberId, Long examId);
-    MemberExam findByMemberIdAndExamIdAndStatus(Long memberId, Long examId, Status status);
 
     @Query(value = "select *"
             + "from member_exam me "

--- a/src/main/java/kr/co/teacherforboss/repository/TagRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/TagRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 @Repository
 public interface TagRepository extends JpaRepository<Tag, Long> {
-    boolean existsByIdAndStatus(Long id, Status status);
+    boolean existsByIdAndExamCategoryIdAndStatus(Long id, Long examCategoryId, Status status);
     List<Tag> findTagsByExamCategoryIdAndStatus(Long categoryId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/TagRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/TagRepository.java
@@ -9,5 +9,6 @@ import java.util.List;
 
 @Repository
 public interface TagRepository extends JpaRepository<Tag, Long> {
+    boolean existsByIdAndStatus(Long id, Status status);
     List<Tag> findTagsByExamCategoryIdAndStatus(Long categoryId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.ExamCategory;
+import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.Question;
 import kr.co.teacherforboss.domain.Tag;
 import kr.co.teacherforboss.domain.enums.ExamQuarter;
@@ -12,7 +13,8 @@ import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 public interface ExamQueryService {
     List<ExamCategory> getExamCategories();
     List<Tag> getTags(Long categoryId);
-    List<ExamResponseDTO.GetExamsDTO.ExamInfo> getExams(Long examCategoryId, Long tagId);
+    List<Exam> getExams(Long examCategoryId, Long tagId);
+    List<MemberExam> getMemberExams();
     List<Question> getQuestions(Long examId);
     List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> getExamRankInfo(Long examId);
     ExamResponseDTO.GetAverageDTO getAverage(ExamQuarter examQuarter);

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
@@ -12,7 +12,7 @@ import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 public interface ExamQueryService {
     List<ExamCategory> getExamCategories();
     List<Tag> getTags(Long categoryId);
-    List<ExamResponseDTO.GetExamsDTO.ExamInfo> getExams(Long memberId, Long examCategoryId, Long tagId);
+    List<ExamResponseDTO.GetExamsDTO.ExamInfo> getExams(Long examCategoryId, Long tagId);
     List<Question> getQuestions(Long examId);
     List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> getExamRankInfo(Long examId);
     ExamResponseDTO.GetAverageDTO getAverage(ExamQuarter examQuarter);

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryService.java
@@ -7,12 +7,12 @@ import kr.co.teacherforboss.domain.ExamCategory;
 import kr.co.teacherforboss.domain.Question;
 import kr.co.teacherforboss.domain.Tag;
 import kr.co.teacherforboss.domain.enums.ExamQuarter;
-import kr.co.teacherforboss.domain.enums.ExamType;
 import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 
 public interface ExamQueryService {
     List<ExamCategory> getExamCategories();
     List<Tag> getTags(Long categoryId);
+    List<ExamResponseDTO.GetExamsDTO.ExamInfo> getExams(Long memberId, Long examCategoryId, Long tagId);
     List<Question> getQuestions(Long examId);
     List<ExamResponseDTO.GetExamRankInfoDTO.ExamRankInfo> getExamRankInfo(Long examId);
     ExamResponseDTO.GetAverageDTO getAverage(ExamQuarter examQuarter);

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -74,7 +74,7 @@ public class ExamQueryServiceImpl implements ExamQueryService {
     @Transactional(readOnly = true)
     public List<MemberExam> getMemberExams() {
         Member member = authCommandService.getMember();
-        return memberExamRepository.findByMemberAndStatus(member, Status.ACTIVE);
+        return memberExamRepository.findRecentByMemberIdGroupByCategoryAndTag(member.getId());
     }
 
     @Override

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -55,6 +55,13 @@ public class ExamQueryServiceImpl implements ExamQueryService {
     @Override
     @Transactional(readOnly = true)
     public List<ExamResponseDTO.GetExamsDTO.ExamInfo> getExams(Long memberId, Long examCategoryId, Long tagId) {
+        if(!examCategoryRepository.existsByIdAndStatus(examCategoryId, Status.ACTIVE)) {
+            throw new ExamHandler(ErrorStatus.EXAM_CATEGORY_NOT_FOUND);
+        }
+        if(!tagRepository.existsByIdAndStatus(tagId, Status.ACTIVE)) {
+            throw new ExamHandler(ErrorStatus.EXAM_TAG_NOT_FOUND);
+        }
+
         List<ExamResponseDTO.GetExamsDTO.ExamInfo> examInfos = new ArrayList<>();
         List<Exam> examList = examRepository.findByExamCategoryIdAndTagIdAndStatus(examCategoryId, tagId, Status.ACTIVE);
 

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -74,7 +74,7 @@ public class ExamQueryServiceImpl implements ExamQueryService {
     @Transactional(readOnly = true)
     public List<MemberExam> getMemberExams() {
         Member member = authCommandService.getMember();
-        return memberExamRepository.findRecentByMemberIdGroupByCategoryAndTag(member.getId());
+        return memberExamRepository.findAllRecentByMemberId(member.getId());
     }
 
     @Override

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -13,7 +13,6 @@ import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.Question;
 import kr.co.teacherforboss.domain.Tag;
 import kr.co.teacherforboss.domain.enums.ExamQuarter;
-import kr.co.teacherforboss.domain.enums.ExamType;
 import kr.co.teacherforboss.domain.enums.Status;
 import kr.co.teacherforboss.repository.ExamCategoryRepository;
 import kr.co.teacherforboss.repository.ExamRepository;
@@ -48,6 +47,31 @@ public class ExamQueryServiceImpl implements ExamQueryService {
     @Transactional(readOnly = true)
     public List<Tag> getTags(Long examCategoryId) {
         return tagRepository.findTagsByExamCategoryIdAndStatus(examCategoryId, Status.ACTIVE);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ExamResponseDTO.GetExamsDTO.ExamInfo> getExams(Long memberId, Long examCategoryId, Long tagId) {
+        List<ExamResponseDTO.GetExamsDTO.ExamInfo> examInfos = new ArrayList<>();
+        List<Exam> examList = examRepository.findByExamCategoryIdAndTagIdAndStatus(examCategoryId, tagId, Status.ACTIVE);
+
+        for (Exam exam : examList) {
+            MemberExam memberExam = memberExamRepository.findByMemberIdAndExamIdAndStatus(memberId, exam.getId(), Status.ACTIVE);
+
+            boolean isTakenExam = memberExam != null;
+            Integer score = null;
+            Boolean isPassed = null;
+
+            if (isTakenExam) {
+                score = memberExam.getScore();
+                isPassed = score >= 70;
+            }
+
+            ExamResponseDTO.GetExamsDTO.ExamInfo examInfo = ExamConverter.toGetExamInfo(exam, isTakenExam, isPassed, score);
+            examInfos.add(examInfo);
+        }
+
+        return examInfos;
     }
 
     @Override

--- a/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImpl.java
@@ -56,12 +56,13 @@ public class ExamQueryServiceImpl implements ExamQueryService {
     @Override
     @Transactional(readOnly = true)
     public List<ExamResponseDTO.GetExamsDTO.ExamInfo> getExams(Long examCategoryId, Long tagId) {
+        if(!examCategoryRepository.existsByIdAndStatus(examCategoryId, Status.ACTIVE))
+            throw new ExamHandler(ErrorStatus.EXAM_CATEGORY_NOT_FOUND);
+
         Member member = authCommandService.getMember();
         List<Exam> examList;
 
         if(tagId == null) {
-            if(!examCategoryRepository.existsByIdAndStatus(examCategoryId, Status.ACTIVE))
-                throw new ExamHandler(ErrorStatus.EXAM_CATEGORY_NOT_FOUND);
             examList = examRepository.findByExamCategoryIdAndStatus(examCategoryId, Status.ACTIVE);
         } else {
             if(!tagRepository.existsByIdAndExamCategoryIdAndStatus(tagId, examCategoryId, Status.ACTIVE))

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import kr.co.teacherforboss.apiPayload.ApiResponse;
 import kr.co.teacherforboss.config.ExamConfig;
+import kr.co.teacherforboss.config.jwt.PrincipalDetails;
 import kr.co.teacherforboss.converter.ExamConverter;
 import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.ExamCategory;
@@ -12,10 +13,12 @@ import kr.co.teacherforboss.domain.Question;
 import kr.co.teacherforboss.domain.Tag;
 import kr.co.teacherforboss.service.examService.ExamCommandService;
 import kr.co.teacherforboss.service.examService.ExamQueryService;
+import kr.co.teacherforboss.validation.annotation.ExistPrincipalDetails;
 import kr.co.teacherforboss.web.dto.ExamRequestDTO;
 import kr.co.teacherforboss.web.dto.ExamResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -54,6 +57,14 @@ public class ExamController {
     public ApiResponse<ExamResponseDTO.GetTagsDTO> getTags(@PathVariable("examCategoryId") Long examCategoryId) {
         List<Tag> tags = examQueryService.getTags(examCategoryId);
         return ApiResponse.onSuccess(ExamConverter.toGetTagsDTO(tags));
+    }
+
+    @GetMapping("/list/{examCategoryId}/{tagId}")
+    public ApiResponse<ExamResponseDTO.GetExamsDTO> getExams(@PathVariable("examCategoryId") Long examCategoryId,
+                                                            @PathVariable("tagId") Long tagId,
+                                                            @ExistPrincipalDetails @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        List<ExamResponseDTO.GetExamsDTO.ExamInfo> examInfos = examQueryService.getExams(principalDetails.getMemberId(), examCategoryId, tagId);
+        return ApiResponse.onSuccess(ExamConverter.toGetExamsDTO(examInfos));
     }
 
     @GetMapping("/member-exams/{memberExamId}/result/incorrect/list")

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -63,8 +63,9 @@ public class ExamController {
     @GetMapping("/list/{examCategoryId}")
     public ApiResponse<ExamResponseDTO.GetExamsDTO> getExams(@PathVariable("examCategoryId") Long examCategoryId,
                                                              @RequestParam(value = "tagId", required = false) Long tagId) {
-        List<ExamResponseDTO.GetExamsDTO.ExamInfo> examInfos = examQueryService.getExams(examCategoryId, tagId);
-        return ApiResponse.onSuccess(ExamConverter.toGetExamsDTO(examInfos));
+        List<Exam> exams = examQueryService.getExams(examCategoryId, tagId);
+        List<MemberExam> memberExams = examQueryService.getMemberExams();
+        return ApiResponse.onSuccess(ExamConverter.toGetExamsDTO(exams, memberExams));
     }
 
     @GetMapping("/member-exams/{memberExamId}/result/incorrect/list")

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -59,10 +60,10 @@ public class ExamController {
         return ApiResponse.onSuccess(ExamConverter.toGetTagsDTO(tags));
     }
 
-    @GetMapping("/list/{examCategoryId}/{tagId}")
+    @GetMapping("/list/{examCategoryId}")
     public ApiResponse<ExamResponseDTO.GetExamsDTO> getExams(@PathVariable("examCategoryId") Long examCategoryId,
-                                                            @PathVariable("tagId") Long tagId,
-                                                            @ExistPrincipalDetails @AuthenticationPrincipal PrincipalDetails principalDetails) {
+                                                             @RequestParam("tagId") Long tagId,
+                                                             @ExistPrincipalDetails @AuthenticationPrincipal PrincipalDetails principalDetails) {
         List<ExamResponseDTO.GetExamsDTO.ExamInfo> examInfos = examQueryService.getExams(principalDetails.getMemberId(), examCategoryId, tagId);
         return ApiResponse.onSuccess(ExamConverter.toGetExamsDTO(examInfos));
     }

--- a/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/ExamController.java
@@ -62,9 +62,8 @@ public class ExamController {
 
     @GetMapping("/list/{examCategoryId}")
     public ApiResponse<ExamResponseDTO.GetExamsDTO> getExams(@PathVariable("examCategoryId") Long examCategoryId,
-                                                             @RequestParam("tagId") Long tagId,
-                                                             @ExistPrincipalDetails @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        List<ExamResponseDTO.GetExamsDTO.ExamInfo> examInfos = examQueryService.getExams(principalDetails.getMemberId(), examCategoryId, tagId);
+                                                             @RequestParam(value = "tagId", required = false) Long tagId) {
+        List<ExamResponseDTO.GetExamsDTO.ExamInfo> examInfos = examQueryService.getExams(examCategoryId, tagId);
         return ApiResponse.onSuccess(ExamConverter.toGetExamsDTO(examInfos));
     }
 

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
@@ -74,7 +74,6 @@ public class ExamResponseDTO {
             private Long examId;
             private String examName;
             private String examDescription;
-            private String tagName;
             private boolean examYN;
             private Boolean examPassYN;
             private Integer examScore;

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
@@ -49,14 +49,14 @@ public class ExamResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GetTagsDTO {
-        private List<TagInfo> tagsList;
+        List<TagInfo> tagsList;
 
         @Builder
         @Getter
         @AllArgsConstructor
         public static class TagInfo {
-            private Long tagId;
-            private String tagName;
+            Long tagId;
+            String tagName;
         }
     }
 
@@ -71,13 +71,13 @@ public class ExamResponseDTO {
         @Getter
         @AllArgsConstructor
         public static class ExamInfo {
-            private Long examId;
-            private String tagName;
-            private String examName;
-            private String examDescription;
-            private boolean examYN;
-            private Boolean examPassYN;
-            private Integer examScore;
+            Long examId;
+            String tagName;
+            String examName;
+            String examDescription;
+            boolean examYN;
+            Boolean examPassYN;
+            Integer examScore;
         }
     }
 

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
@@ -77,13 +77,13 @@ public class ExamResponseDTO {
         @Getter
         @AllArgsConstructor
         public static class ExamInfo {
-            private String name;
-            private String description;
+            private Long examId;
+            private String examName;
+            private String examDescription;
             private String tagName;
-            private String examCategoryName;
-            private boolean isTakenExam;
-            private Boolean isPassed;
-            private Integer score;
+            private boolean examYN;
+            private Boolean examPassYN;
+            private Integer examScore;
         }
     }
 

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
@@ -70,6 +70,27 @@ public class ExamResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class GetExamsDTO {
+        List<ExamInfo> examList;
+
+        @Builder
+        @Getter
+        @AllArgsConstructor
+        public static class ExamInfo {
+            private String name;
+            private String description;
+            private String tagName;
+            private String examCategoryName;
+            private boolean isTakenExam;
+            private Boolean isPassed;
+            private Integer score;
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class GetExamIncorrectAnswersResultDTO {
         List<ExamIncorrectQuestion> examIncorrectQuestionList;
 

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
@@ -71,13 +71,13 @@ public class ExamResponseDTO {
         @Getter
         @AllArgsConstructor
         public static class ExamInfo {
-            Long examId;
-            String tagName;
-            String examName;
-            String examDescription;
-            boolean examYN;
-            Boolean examPassYN;
-            Integer examScore;
+            Long id;
+            String tag;
+            String name;
+            String description;
+            boolean isTaken;
+            Boolean isPassed;
+            Integer score;
         }
     }
 

--- a/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/ExamResponseDTO.java
@@ -72,6 +72,7 @@ public class ExamResponseDTO {
         @AllArgsConstructor
         public static class ExamInfo {
             private Long examId;
+            private String tagName;
             private String examName;
             private String examDescription;
             private boolean examYN;


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #132 

## 📝 작업 내용

**시험 리스트 조회 API 구현**
* 시험명
* 시험 세부 설명
* 시험 태그
* 시험 카테고리
* 시험 응시여부
* 시험 오답률
* 시험 점수
* 시험 PASS/FAIL 여부

![316689867-7fd51368-b08b-4612-98a1-6a8e48435edc](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/113760409/78038926-ead7-48c6-bed2-ea530367762c)
![316689920-409084ff-d157-4296-a6db-a6fcf891cf0e](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/113760409/0fef79c2-47ec-4bca-898c-35c36268cc37)


## 📝 예외 처리

멤버 토큰이 유효하지 않을 경우, 오류 메시지 반환

## 💬 리뷰 요구사항(선택)
