### PR TITLE
♻️ [REFACTOR] 같은 업종 사장님 평균 점수 조회 API 쿼리 리팩토링 & 동시성 테스트

### DIFF
--- a/src/main/java/kr/co/teacherforboss/domain/Member.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Member.java
@@ -29,7 +29,7 @@ public class Member extends BaseEntity {
     private String name;
 
     @NotNull
-    @Column(length = 100)
+    @Column(length = 100, unique = true)
     private String email;
 
     @NotNull
@@ -59,7 +59,7 @@ public class Member extends BaseEntity {
     private Gender gender;
 
     @NotNull
-    @Column(length = 50)
+    @Column(length = 50, unique = true)
     private String phone;
 
     @Column

--- a/src/main/java/kr/co/teacherforboss/domain/Member.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Member.java
@@ -25,10 +25,9 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(uniqueConstraints = {
-        @UniqueConstraint(
-                name="UNIQUE_EMAIL_PHONE",
-                columnNames={"email","phone"}
-        )})
+        @UniqueConstraint(name= "member_email_uk", columnNames={ "email" }),
+        @UniqueConstraint(name= "member_phone_uk", columnNames={ "phone" })
+})
 public class Member extends BaseEntity {
 
     @NotNull

--- a/src/main/java/kr/co/teacherforboss/domain/Member.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Member.java
@@ -4,6 +4,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 import kr.co.teacherforboss.domain.common.BaseEntity;
 import kr.co.teacherforboss.domain.enums.Gender;
@@ -22,6 +24,11 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                name="UNIQUE_EMAIL_PHONE",
+                columnNames={"email","phone"}
+        )})
 public class Member extends BaseEntity {
 
     @NotNull
@@ -29,7 +36,7 @@ public class Member extends BaseEntity {
     private String name;
 
     @NotNull
-    @Column(length = 100, unique = true)
+    @Column(length = 100)
     private String email;
 
     @NotNull
@@ -59,7 +66,7 @@ public class Member extends BaseEntity {
     private Gender gender;
 
     @NotNull
-    @Column(length = 50, unique = true)
+    @Column(length = 50)
     private String phone;
 
     @Column

--- a/src/main/java/kr/co/teacherforboss/repository/ExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/ExamRepository.java
@@ -3,12 +3,10 @@ package kr.co.teacherforboss.repository;
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.persistence.QueryHint;
 import kr.co.teacherforboss.domain.Exam;
 import kr.co.teacherforboss.domain.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -19,7 +17,6 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     Optional<Exam> findByIdAndStatus(Long examId, Status status);
     boolean existsByIdAndStatus(Long id, Status status);
 
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     @Query(value = "SELECT e.* " +
             "FROM exam e " +
             "WHERE EXISTS ( " +

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -9,7 +9,6 @@ import kr.co.teacherforboss.domain.MemberExam;
 import kr.co.teacherforboss.domain.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -72,14 +71,12 @@ public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
             + "where me1_0.id = :id", nativeQuery = true)
     Long findRankById(@Param("id") Long id);
 
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     @Query(value = "select round(avg(me.score)) from member_exam me " +
             "where me.member_id = :memberId " +
             "and month(me.created_at) >= :first and month(me.created_at) <= :last " +
             "and me.status = 'ACTIVE'", nativeQuery = true)
     Optional<Integer> getAverageByMemberId(@Param("memberId") Long memberId, @Param("first") int first, @Param("last") int last);
 
-    @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     @Query(value = "select round(avg(me.score)) from member_exam me " +
             "where me.member_id <> :memberId " +
             "and month(me.created_at) >= :first and month(me.created_at) <= :last " +

--- a/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberExamRepository.java
@@ -81,8 +81,7 @@ public interface MemberExamRepository extends JpaRepository<MemberExam, Long> {
 
     @QueryHints(value = @QueryHint(name = "org.hibernate.readOnly", value = "true"))
     @Query(value = "select round(avg(me.score)) from member_exam me " +
-            "left outer join (select member_id from member_exam where member_id = :memberId) m on me.member_id = m.member_id " +
-            "where m.member_id is null " +
+            "where me.member_id <> :memberId " +
             "and month(me.created_at) >= :first and month(me.created_at) <= :last " +
             "and me.status = 'ACTIVE'", nativeQuery = true)
     Optional<Integer> getAverageByMemberIdNot(@Param("memberId") Long memberId, @Param("first") int first, @Param("last") int last);

--- a/src/test/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImplTest.java
+++ b/src/test/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImplTest.java
@@ -37,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.will;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
@@ -62,8 +61,6 @@ public class AuthCommandServiceImplTest {
     private CodeMail codeMail;
     @InjectMocks
     private AuthTestUtil authTestUtil;
-    @Mock
-    private PasswordUtil passwordUtil;
 
     /*
     // TODO: 이메일 인증 테스트
@@ -111,7 +108,7 @@ public class AuthCommandServiceImplTest {
     @Test
     void joinMember() {
         // given
-        Member expected = authTestUtil.generateMemberDummy();
+        Member expected = authTestUtil.generateMemberDummy("email@gmail.com");
         AuthRequestDTO.JoinDTO request = request("백채연", "email@gmail.com", "asdf1234", "asdf1234", 2, "01012341234", "T"); // request로 입력한 Member data
         AgreementTerm mockAgreement = authTestUtil.generateAgreementTerm();
         doReturn(expected).when(memberRepository)
@@ -170,7 +167,7 @@ public class AuthCommandServiceImplTest {
     void findEmail() {
         // given
         PhoneAuth phoneAuth = authTestUtil.generatePhoneAuthDummy();
-        Member member = authTestUtil.generateMemberDummy();
+        Member member = authTestUtil.generateMemberDummy("email@gmail.com");
 
         AuthRequestDTO.FindEmailDTO request = toFindEmail(1L);
         doReturn(Optional.of(phoneAuth)).when(phoneAuthRepository).findById(any(Long.class));
@@ -221,7 +218,7 @@ public class AuthCommandServiceImplTest {
     void findPassword() {
         // given
         EmailAuth emailAuth = authTestUtil.generateFindPwCheckEmailAuthDummy("email@gmail.com");
-        Member member = authTestUtil.generateMemberDummy();
+        Member member = authTestUtil.generateMemberDummy("email@gmail.com");
         AuthRequestDTO.FindPasswordDTO request = toFindPassword(1L);
 
         doReturn(Optional.of(emailAuth)).when(emailAuthRepository).findById(anyLong());

--- a/src/test/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImplTest.java
+++ b/src/test/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImplTest.java
@@ -2,9 +2,13 @@ package kr.co.teacherforboss.service.authService;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
 import kr.co.teacherforboss.apiPayload.exception.GeneralException;
@@ -22,7 +26,6 @@ import kr.co.teacherforboss.repository.MemberRepository;
 import kr.co.teacherforboss.repository.PhoneAuthRepository;
 import kr.co.teacherforboss.service.mailService.MailCommandService;
 import kr.co.teacherforboss.util.AuthTestUtil;
-import kr.co.teacherforboss.util.PasswordUtil;
 import kr.co.teacherforboss.web.dto.AuthRequestDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +36,8 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.query.sqm.tree.SqmNode.log;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -139,6 +144,44 @@ public class AuthCommandServiceImplTest {
 
         // then
         assertThat(e.getCode()).isEqualTo(ErrorStatus.INVALID_AGREEMENT_TERM);
+    }
+
+    @Test
+    @DisplayName("회원 가입 - 동시성 테스트")
+    void joinMemberWithConcurrent() throws InterruptedException {
+        // given
+        Member expected = authTestUtil.generateMemberDummy("email@gmail.com");
+        AuthRequestDTO.JoinDTO request = request("백채연", "email@gmail.com", "asdf1234", "asdf1234", 2, "01012341234", "T"); // request로 입력한 Member data
+
+        doReturn(expected).when(memberRepository)
+                .save(any(Member.class));
+
+        ExecutorService executorService = Executors.newFixedThreadPool(5);
+        CountDownLatch latch = new CountDownLatch(5);
+
+        // when
+        log.info("회원가입 동시성 테스트 진행");
+        ArrayList<Member> memberList = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            executorService.execute(() -> {
+                Member member = memberRepository.save(authCommandService.joinMember(request));
+                if (memberList.isEmpty()){
+                    memberList.add(member);
+                }
+                else{
+                    for (Member m : memberList) {
+                        if (!m.getEmail().equals(member.getEmail())) {
+                            memberList.add(member);
+                        }
+                    }
+                }
+                latch.countDown();
+            });
+        }
+        latch.await();
+
+        // then
+        assertEquals(memberList.size(), 1);
     }
 
     private AuthRequestDTO.JoinDTO request(String name, String email, String pw, String rePw, Integer gender, String phone, String agreement){

--- a/src/test/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImplTest.java
+++ b/src/test/java/kr/co/teacherforboss/service/examService/ExamQueryServiceImplTest.java
@@ -1,0 +1,50 @@
+package kr.co.teacherforboss.service.examService;
+
+import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
+import kr.co.teacherforboss.apiPayload.exception.GeneralException;
+import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.enums.ExamQuarter;
+import kr.co.teacherforboss.domain.enums.Status;
+import kr.co.teacherforboss.repository.MemberExamRepository;
+import kr.co.teacherforboss.util.AuthTestUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class ExamQueryServiceImplTest {
+
+    @Mock
+    private MemberExamRepository memberExamRepository;
+    @InjectMocks
+    private AuthTestUtil authTestUtil;
+
+    /*
+    // TODO: 평균 조회
+     */
+    @DisplayName("평균 조회 (성공)")
+    @Test
+    void getAverage() {
+        // given
+        Member member = authTestUtil.generateMemberDummy("email@gmail.com");
+
+        doReturn(Optional.of(Integer.class)).when(memberExamRepository).getAverageByMemberId(member.getId(), 1, 12);
+        doReturn(Optional.of(Integer.class)).when(memberExamRepository).getAverageByMemberIdNot(member.getId(), 1, 12);
+
+        // when
+        Optional<Integer> memberScore = memberExamRepository.getAverageByMemberId(member.getId(), 1, 12);
+        Optional<Integer> otherScore = memberExamRepository.getAverageByMemberIdNot(member.getId(), 1, 12);
+
+        // then
+        assertThat(memberScore).isNotNull();
+        assertThat(otherScore).isNotNull();
+    }
+}

--- a/src/test/java/kr/co/teacherforboss/service/memberService/MemberQueryServiceImplTest.java
+++ b/src/test/java/kr/co/teacherforboss/service/memberService/MemberQueryServiceImplTest.java
@@ -47,7 +47,7 @@ class MemberQueryServiceImplTest {
     @DisplayName("프로필 조회 (성공) - ACTIVE 상태의 사용자 이름과 프로필 이미지 조회")
     void getMemberProfile() {
         // given
-        Member member = authTestUtil.generateMemberDummy();
+        Member member = authTestUtil.generateMemberDummy("email@gmail.com");
         when(authCommandService.getMember())
                 .thenReturn(member);
         when(memberRepository.findByIdAndStatus(any(), any()))
@@ -65,7 +65,7 @@ class MemberQueryServiceImplTest {
     @DisplayName("프로필 조회 (실패) - 존재하지 않는 사용자 이름과 프로필 이미지 조회")
     void failGetMemberProfile() {
         // given
-        Member member = authTestUtil.generateMemberDummy(); // 조회하려는 사용자
+        Member member = authTestUtil.generateMemberDummy("email@gmail.com"); // 조회하려는 사용자
         when(authCommandService.getMember())
                 .thenReturn(member);
         when(memberRepository.findByIdAndStatus(member.getId(), Status.ACTIVE))

--- a/src/test/java/kr/co/teacherforboss/util/AuthTestUtil.java
+++ b/src/test/java/kr/co/teacherforboss/util/AuthTestUtil.java
@@ -24,11 +24,11 @@ public class AuthTestUtil {
 
     }
 
-    public Member generateMemberDummy(){
+    public Member generateMemberDummy(String email){
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         return Member.builder()
                 .name("백채연")
-                .email("email@gmail.com")
+                .email(email)
                 .loginType(LoginType.GENERAL)
                 .role(Role.USER)
                 .birthDate(LocalDate.parse("2000-04-22", formatter))

--- a/src/test/java/kr/co/teacherforboss/util/ExamTestUtil.java
+++ b/src/test/java/kr/co/teacherforboss/util/ExamTestUtil.java
@@ -34,4 +34,13 @@ public class ExamTestUtil {
                 .commentary("해설")
                 .build();
     }
+
+    public MemberExam generateMemberExam(Exam exam, Member member){
+        return MemberExam.builder()
+                .member(member)
+                .exam(exam)
+                .score(70)
+                .time(100000L)
+                .build();
+    }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #137 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- Jmeter와 Junit을 활용하여 평균 점수 조회 쿼리 성능 개선을 위한 리팩토링을 진행했습니다.
- 로컬 DB에 약 5천 건의 데이터를 삽입해 API 부하 테스트를 진행했습니다.
1. MemberExam 리스트로 반환 -> 이전에 민지님과 PR 코멘트로 재사용 가능성에 대해 고민하며 추후 성능 테스트를 통해 해당 부분을 적용할지 이야기를 나눴었는데, 실제 테스트 결과 적은 더미 데이터만으로도 성능이 떨어져서 패스했습니다.. ㅎ
2. 쿼리 힌트 적용 -> 약 200ms 가량 감소하여 적용
3. BETWEEN 대신 부등호 조건 -> 검색 시작점이 달라져 약 100-200ms이 더 줄어들었습니다
4. 부정형 조건 대신 left outer join -> 부정형 조건을 적용하는 경우 부정형 조건 그 외의 범위를 다 탐색하기에, join을 통해 null 값을 찾는 쿼리로 수정한 후 테스트를 해봤습니다. 이론과는 다르게 약 N배 가량 시간이 지연되어 이 부분은 패스....

블로그에 기록하며 작성했는데 혹시 궁금하시다면 코멘트로 달아두겠습니다!
테스트 코드도 간단하게 작성해서 로직 비교해가며 실행했습니다 !

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
