### PR TITLE
✨[FEAT] 티쳐/보스 구분에 따른 회원가입/소셜로그인 API 로직 추가 & 닉네임 중복 검사 API

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -54,7 +54,10 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_OPEN_DATE_EMPTY(BAD_REQUEST, "MEMBER40012", "개업연월일은 필수 입니다."),
     MEMBER_ROLE_INVALID(BAD_REQUEST, "MEMBER40013", "유효하지 않은 역할 값입니다."),
     MEMBER_DATE_INVALID(BAD_REQUEST, "MEMBER40014", "날짜 형식이 옳바르지 않습니다."),
-    MEMBER_NICKNAME_DUPLICATE(BAD_REQUEST, "MEMBER4015", "이미 존재하는 닉네임입니다."),
+    MEMBER_BANK_EMPTY(BAD_REQUEST, "MEMBER40015", "은행 선택은 필수 입니다."),
+    MEMBER_ACCOUNT_NUM_EMPTY(BAD_REQUEST, "MEMBER40016", "계좌번호 입력은 필수 입니다."),
+    MEMBER_ACCOUNT_HOLDER_EMPTY(BAD_REQUEST, "MEMBER40017", "예금주명 입력은 필수 입니다."),
+    MEMBER_NICKNAME_DUPLICATE(BAD_REQUEST, "MEMBER4018", "이미 존재하는 닉네임입니다."),
 
     MEMBER_NOT_FOUND(NOT_FOUND, "MEMBER4041", "사용자가 없습니다."),
 

--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -54,6 +54,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_OPEN_DATE_EMPTY(BAD_REQUEST, "MEMBER40012", "개업연월일은 필수 입니다."),
     MEMBER_ROLE_INVALID(BAD_REQUEST, "MEMBER40013", "유효하지 않은 역할 값입니다."),
     MEMBER_DATE_INVALID(BAD_REQUEST, "MEMBER40014", "날짜 형식이 옳바르지 않습니다."),
+    MEMBER_NICKNAME_DUPLICATE(BAD_REQUEST, "MEMBER4015", "이미 존재하는 닉네임입니다."),
 
     MEMBER_NOT_FOUND(NOT_FOUND, "MEMBER4041", "사용자가 없습니다."),
 

--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -45,6 +45,15 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_PHONE_DUPLICATE(BAD_REQUEST, "MEMBER4003", "이미 존재하는 휴대전화 번호입니다."),
     GENERAL_MEMBER_DUPLICATE(BAD_REQUEST, "MEMBER4004", "일반 회원가입을 통해 진행한 이메일 계정입니다."),
     SOCIAL_MEMBER_INFO_EMPTY(BAD_REQUEST, "MEMBER4005", "소셜 회원가입에 필요한 값이 없습니다."),
+    MEMBER_FIELD_EMPTY(BAD_REQUEST, "MEMBER4006", "분야는 필수 입니다"),
+    MEMBER_CAREER_EMPTY(BAD_REQUEST, "MEMBER4007", "경력은 필수 입니다"),
+    MEMBER_INTRODUCTION_EMPTY(BAD_REQUEST, "MEMBER4008", "한줄 소개는 필수 입니다."),
+    MEMBER_KEYWORDS_EMPTY(BAD_REQUEST, "MEMBER4009", "키워드 선택은 필수 입니다."),
+    MEMBER_BUSINESS_NUM_EMPTY(BAD_REQUEST, "MEMBER40010", "사업자 등록 번호는 필수 입니다."),
+    MEMBER_REPRESENTATIVE_EMPTY(BAD_REQUEST, "MEMBER40011", "대표자명은 필수 입니다."),
+    MEMBER_OPEN_DATE_EMPTY(BAD_REQUEST, "MEMBER40012", "개업연월일은 필수 입니다."),
+    MEMBER_ROLE_INVALID(BAD_REQUEST, "MEMBER40013", "유효하지 않은 역할 값입니다."),
+    MEMBER_DATE_INVALID(BAD_REQUEST, "MEMBER40014", "날짜 형식이 옳바르지 않습니다."),
 
     MEMBER_NOT_FOUND(NOT_FOUND, "MEMBER4041", "사용자가 없습니다."),
 

--- a/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
@@ -40,6 +40,7 @@ public class AuthConverter {
     }
 
     public static TeacherInfo toTeacher(AuthRequestDTO.JoinCommonDTO request){
+        String keywords = String.join(";", request.getKeywords());
         return TeacherInfo.builder()
                 .businessNumber(request.getBusinessNum())
                 .representative(request.getRepresentative())
@@ -47,7 +48,7 @@ public class AuthConverter {
                 .field(request.getField())
                 .career(request.getCareer())
                 .introduction(request.getIntroduction())
-                .keywords(request.getKeywords())
+                .keywords(keywords)
                 .level(Level.LEVEL1)
                 .bank(request.getBank())
                 .accountNumber(request.getAccountNum())

--- a/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
@@ -58,6 +58,9 @@ public class AuthConverter {
                 .introduction(request.getIntroduction())
                 .keywords(request.getKeywords())
                 .level(Level.LEVEL1)
+                .bank(request.getBank())
+                .accountNum(request.getAccountNum())
+                .accountHolder(request.getAccountHolder())
                 .build();
     }
 

--- a/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
@@ -42,7 +42,7 @@ public class AuthConverter {
     public static TeacherInfo toTeacher(AuthRequestDTO.JoinCommonDTO request){
         String keywords = String.join(";", request.getKeywords());
         return TeacherInfo.builder()
-                .businessNumber(request.getBusinessNum())
+                .businessNumber(request.getBusinessNumber())
                 .representative(request.getRepresentative())
                 .openDate(request.getOpenDate())
                 .field(request.getField())
@@ -51,7 +51,7 @@ public class AuthConverter {
                 .keywords(keywords)
                 .level(Level.LEVEL1)
                 .bank(request.getBank())
-                .accountNumber(request.getAccountNum())
+                .accountNumber(request.getAccountNumber())
                 .accountHolder(request.getAccountHolder())
                 .build();
     }

--- a/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
@@ -3,7 +3,9 @@ package kr.co.teacherforboss.converter;
 import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.EmailAuth;
 import kr.co.teacherforboss.domain.PhoneAuth;
+import kr.co.teacherforboss.domain.TeacherInfo;
 import kr.co.teacherforboss.domain.enums.Gender;
+import kr.co.teacherforboss.domain.enums.Level;
 import kr.co.teacherforboss.domain.enums.LoginType;
 import kr.co.teacherforboss.domain.enums.Role;
 import kr.co.teacherforboss.domain.enums.Purpose;
@@ -29,17 +31,36 @@ public class AuthConverter {
             default -> Gender.NONE;
         };
 
+        Role role = switch (request.getRole()) {
+            case 2 -> Role.TEACHER;
+            case 3 -> Role.ADMIN;
+            default -> Role.BOSS;
+        };
+
         return Member.builder()
                 .name(request.getName())
                 .email(request.getEmail())
                 .loginType(LoginType.GENERAL)
-                .role(Role.USER)
+                .role(role)
                 .gender(gender)
                 .birthDate(request.getBirthDate())
                 .phone(request.getPhone())
                 .build();
     }
-    
+
+    public static TeacherInfo toTeacher(AuthRequestDTO.JoinCommonDTO request){
+        return TeacherInfo.builder()
+                .businessNum(request.getBusinessNum())
+                .representative(request.getRepresentative())
+                .openDate(request.getOpenDate())
+                .field(request.getField())
+                .career(request.getCareer())
+                .introduction(request.getIntroduction())
+                .keywords(request.getKeywords())
+                .level(Level.LEVEL1)
+                .build();
+    }
+
     public static AuthResponseDTO.SendCodeMailResultDTO toSendCodeMailResultDTO(EmailAuth emailAuth) {
         return AuthResponseDTO.SendCodeMailResultDTO.builder()
                 .emailAuthId(emailAuth.getId())
@@ -95,7 +116,7 @@ public class AuthConverter {
                 .memberId(member.getId())
                 .isChanged(true)
                 .build();
-  }
+    }
   
     public static AuthResponseDTO.FindEmailResultDTO toFindEmailResultDTO(Member member) {
         return AuthResponseDTO.FindEmailResultDTO.builder()
@@ -111,10 +132,16 @@ public class AuthConverter {
             default -> Gender.NONE;
         };
 
+        Role role = switch (request.getRole()) {
+            case 2 -> Role.TEACHER;
+            case 3 -> Role.ADMIN;
+            default -> Role.BOSS;
+        };
+
         return Member.builder()
                 .name(request.getName())
                 .email(request.getEmail())
-                .role(Role.USER)
+                .role(role)
                 .gender(gender)
                 .loginType(LoginType.of(socialType))
                 .birthDate(request.getBirthDate())
@@ -129,6 +156,12 @@ public class AuthConverter {
                 .agreementSms(request.getAgreementSms())
                 .agreementEmail(request.getAgreementEmail())
                 .agreementLocation(request.getAgreementLocation())
+                .build();
+    }
+
+    public static AuthResponseDTO.CheckNicknameResultDTO toCheckNicknameDTO(Boolean nicknameCheck) {
+        return AuthResponseDTO.CheckNicknameResultDTO.builder()
+                .nicknameCheck(nicknameCheck)
                 .build();
     }
 }

--- a/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
@@ -25,17 +25,8 @@ public class AuthConverter {
     }
 
     public static Member toMember(AuthRequestDTO.JoinDTO request){
-        Gender gender = switch (request.getGender()) {
-            case 1 -> Gender.MALE;
-            case 2 -> Gender.FEMALE;
-            default -> Gender.NONE;
-        };
-
-        Role role = switch (request.getRole()) {
-            case 2 -> Role.TEACHER;
-            case 3 -> Role.ADMIN;
-            default -> Role.BOSS;
-        };
+        Gender gender = Gender.of(request.getGender());
+        Role role = Role.of(request.getRole());
 
         return Member.builder()
                 .name(request.getName())
@@ -50,7 +41,7 @@ public class AuthConverter {
 
     public static TeacherInfo toTeacher(AuthRequestDTO.JoinCommonDTO request){
         return TeacherInfo.builder()
-                .businessNum(request.getBusinessNum())
+                .businessNumber(request.getBusinessNum())
                 .representative(request.getRepresentative())
                 .openDate(request.getOpenDate())
                 .field(request.getField())
@@ -59,7 +50,7 @@ public class AuthConverter {
                 .keywords(request.getKeywords())
                 .level(Level.LEVEL1)
                 .bank(request.getBank())
-                .accountNum(request.getAccountNum())
+                .accountNumber(request.getAccountNum())
                 .accountHolder(request.getAccountHolder())
                 .build();
     }
@@ -129,17 +120,8 @@ public class AuthConverter {
     }
   
     public static Member toSocialMember(AuthRequestDTO.SocialLoginDTO request, int socialType){
-        Gender gender = switch (request.getGender()) {
-            case 1 -> Gender.MALE;
-            case 2 -> Gender.FEMALE;
-            default -> Gender.NONE;
-        };
-
-        Role role = switch (request.getRole()) {
-            case 2 -> Role.TEACHER;
-            case 3 -> Role.ADMIN;
-            default -> Role.BOSS;
-        };
+        Gender gender = Gender.of(request.getGender());
+        Role role = Role.of(request.getRole());
 
         return Member.builder()
                 .name(request.getName())

--- a/src/main/java/kr/co/teacherforboss/domain/Member.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Member.java
@@ -77,4 +77,8 @@ public class Member extends BaseEntity {
         this.pwHash = pwHash;
     }
 
+    public void setProfile(String nickname, String profileImg){
+        this.nickname = nickname;
+        this.profileImg = profileImg;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/domain/Member.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Member.java
@@ -29,6 +29,10 @@ public class Member extends BaseEntity {
     private String name;
 
     @NotNull
+    @Column(length = 10)
+    private String nickname;
+
+    @NotNull
     @Column(length = 100)
     private String email;
 

--- a/src/main/java/kr/co/teacherforboss/domain/Member.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Member.java
@@ -16,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Entity
 @Getter
@@ -72,9 +73,9 @@ public class Member extends BaseEntity {
     @Column
     private LocalDate inactiveDate;
 
-    public void setPassword(String pwSalt, String pwHash){
-        this.pwSalt = pwSalt;
-        this.pwHash = pwHash;
+    public void setPassword(List<String> passwordList){
+        this.pwSalt = passwordList.get(0);
+        this.pwHash = passwordList.get(1);
     }
 
     public void setProfile(String nickname, String profileImg){

--- a/src/main/java/kr/co/teacherforboss/domain/TeacherInfo.java
+++ b/src/main/java/kr/co/teacherforboss/domain/TeacherInfo.java
@@ -38,11 +38,11 @@ public class TeacherInfo extends BaseEntity {
 
     @NotNull
     @Column(length = 200)
-    private String account_num;
+    private String accountNum;
 
     @NotNull
     @Column(length = 20)
-    private String account_holder;
+    private String accountHolder;
 
     @NotNull
     @Column(length = 20)

--- a/src/main/java/kr/co/teacherforboss/domain/TeacherInfo.java
+++ b/src/main/java/kr/co/teacherforboss/domain/TeacherInfo.java
@@ -1,0 +1,66 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.validation.constraints.NotNull;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import kr.co.teacherforboss.domain.enums.Level;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class TeacherInfo extends BaseEntity {
+
+    @NotNull
+    @Column(length = 100)
+    private String businessNum;
+
+    @NotNull
+    @Column(length = 20)
+    private String representative;
+
+    @NotNull
+    @Column
+    private LocalDate openDate;
+
+    @NotNull
+    @Column(length = 10)
+    private String bank;
+
+    @NotNull
+    @Column(length = 200)
+    private String account_num;
+
+    @NotNull
+    @Column(length = 20)
+    private String account_holder;
+
+    @NotNull
+    @Column(length = 20)
+    private String field;
+
+    @NotNull
+    @Column
+    private Integer career;
+
+    @NotNull
+    @Column(length = 40)
+    private String introduction;
+
+    @NotNull
+    @Column(length = 30)
+    private String keywords;
+
+    @NotNull
+    @Column(length = 10)
+    private Level level;
+}

--- a/src/main/java/kr/co/teacherforboss/domain/TeacherInfo.java
+++ b/src/main/java/kr/co/teacherforboss/domain/TeacherInfo.java
@@ -22,7 +22,7 @@ public class TeacherInfo extends BaseEntity {
 
     @NotNull
     @Column(length = 100)
-    private String businessNum;
+    private String businessNumber;
 
     @NotNull
     @Column(length = 20)
@@ -38,7 +38,7 @@ public class TeacherInfo extends BaseEntity {
 
     @NotNull
     @Column(length = 200)
-    private String accountNum;
+    private String accountNumber;
 
     @NotNull
     @Column(length = 20)

--- a/src/main/java/kr/co/teacherforboss/domain/enums/Gender.java
+++ b/src/main/java/kr/co/teacherforboss/domain/enums/Gender.java
@@ -1,5 +1,20 @@
 package kr.co.teacherforboss.domain.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Gender {
-    MALE, FEMALE, NONE
+    MALE(1),
+    FEMALE(2),
+    NONE(3);
+
+    private final int identifier;
+
+    public static Gender of(int identifier) {
+        if (identifier == 1) return MALE;
+        if (identifier == 2) return FEMALE;
+        return NONE;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/domain/enums/Level.java
+++ b/src/main/java/kr/co/teacherforboss/domain/enums/Level.java
@@ -1,0 +1,17 @@
+package kr.co.teacherforboss.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Level {
+    NONE(""),
+    LEVEL1("Lv.1 행운의 별"),
+    LEVEL2("Lv.2 열정의 별"),
+    LEVEL3("Lv.3 신뢰의 별"),
+    LEVEL4("Lv.4 지식의 별"),
+    LEVEL5("Lv.5 성공의 별");
+
+    private final String level;
+}

--- a/src/main/java/kr/co/teacherforboss/domain/enums/Role.java
+++ b/src/main/java/kr/co/teacherforboss/domain/enums/Role.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Role {
+    NONE(0),
     BOSS(1),
     TEACHER(2),
     ADMIN(3);
@@ -13,8 +14,9 @@ public enum Role {
     private final int identifier;
 
     public static Role of(int identifier) {
+        if (identifier == 1) return BOSS;
         if (identifier == 2) return TEACHER;
         if (identifier == 3) return ADMIN;
-        return BOSS;
+        return NONE;
     }
 }

--- a/src/main/java/kr/co/teacherforboss/domain/enums/Role.java
+++ b/src/main/java/kr/co/teacherforboss/domain/enums/Role.java
@@ -1,5 +1,20 @@
 package kr.co.teacherforboss.domain.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Role {
-    USER, ADMIN, TEACHER
+    BOSS(1),
+    TEACHER(2),
+    ADMIN(3);
+
+    private final int identifier;
+
+    public static Role of(int identifier) {
+        if (identifier == 2) return TEACHER;
+        if (identifier == 3) return ADMIN;
+        return BOSS;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/repository/MemberRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/MemberRepository.java
@@ -18,4 +18,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmailAndLoginTypeAndStatus(String email, LoginType loginType, Status status);
     boolean existsByEmailAndStatus(String email, Status status);
     boolean existsByPhoneAndStatus(String phone, Status status);
+    boolean existsByNicknameAndStatus(String nickname, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/TeacherInfoRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/TeacherInfoRepository.java
@@ -1,0 +1,10 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.TeacherInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TeacherInfoRepository extends JpaRepository<TeacherInfo, Long> {
+
+}

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandService.java
@@ -19,6 +19,5 @@ public interface AuthCommandService {
     Member findEmail(AuthRequestDTO.FindEmailDTO request);
     Member getMember();
     Member socialLogin(AuthRequestDTO.SocialLoginDTO request, int socialType);
-    void enterBossInfo(AuthRequestDTO.JoinCommonDTO request, Member member);
-    void enterTeacherInfo(AuthRequestDTO.JoinCommonDTO request, Member member);
+    void saveTeacherInfo(AuthRequestDTO.JoinCommonDTO request, Member member);
 }

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandService.java
@@ -19,4 +19,6 @@ public interface AuthCommandService {
     Member findEmail(AuthRequestDTO.FindEmailDTO request);
     Member getMember();
     Member socialLogin(AuthRequestDTO.SocialLoginDTO request, int socialType);
+    void enterBossInfo(AuthRequestDTO.JoinCommonDTO request, Member member);
+    void enterTeacherInfo(AuthRequestDTO.JoinCommonDTO request, Member member);
 }

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandService.java
@@ -19,5 +19,4 @@ public interface AuthCommandService {
     Member findEmail(AuthRequestDTO.FindEmailDTO request);
     Member getMember();
     Member socialLogin(AuthRequestDTO.SocialLoginDTO request, int socialType);
-    void saveTeacherInfo(AuthRequestDTO.JoinCommonDTO request, Member member);
 }

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
@@ -2,6 +2,7 @@ package kr.co.teacherforboss.service.authService;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
 import kr.co.teacherforboss.apiPayload.exception.GeneralException;
@@ -69,7 +70,8 @@ public class AuthCommandServiceImpl implements AuthCommandService {
             throw new AuthHandler(ErrorStatus.MEMBER_NICKNAME_DUPLICATE);
 
         Member newMember = AuthConverter.toMember(request);
-        passwordUtil.setMemberPassword(newMember, request.getPassword());
+        List<String> passwordList = passwordUtil.generatePassword(request.getRePassword());
+        newMember.setPassword(passwordList);
 
         AgreementTerm newAgreement = AuthConverter.toAgreementTerm(request, newMember);
 
@@ -221,7 +223,8 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         if (!request.getPassword().equals(request.getRePassword()))
             throw new AuthHandler(ErrorStatus.PASSWORD_NOT_CORRECT);
 
-        passwordUtil.setMemberPassword(member, request.getRePassword());
+        List<String> passwordList = passwordUtil.generatePassword(request.getRePassword());
+        member.setPassword(passwordList);
 
         return memberRepository.save(member);
     }
@@ -242,7 +245,8 @@ public class AuthCommandServiceImpl implements AuthCommandService {
             throw new AuthHandler(ErrorStatus.MEMBER_NICKNAME_DUPLICATE);
 
         Member newMember = AuthConverter.toSocialMember(request, socialType);
-        passwordUtil.setSocialMemberPassword(newMember);
+        List<String> passwordList = passwordUtil.generateSocialMemberPassword();
+        newMember.setPassword(passwordList);
 
         newMember.setProfile(request.getNickname(), request.getProfileImg());
         if (request.getRole().equals(2)) saveTeacherInfo(request, newMember);

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
@@ -250,12 +250,10 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         return memberRepository.save(newMember);
     }
 
-    @Override
-    @Transactional
-    public void saveTeacherInfo(AuthRequestDTO.JoinCommonDTO request, Member member) {
+    private void saveTeacherInfo(AuthRequestDTO.JoinCommonDTO request, Member member) {
         // TODO : 사업자 인증 여부 확인 로직 추가
 
-        if (request.getBusinessNum() == null)
+        if (request.getBusinessNumber() == null)
             throw new AuthHandler(ErrorStatus.MEMBER_BUSINESS_NUM_EMPTY);
         if (request.getRepresentative() == null)
             throw new AuthHandler(ErrorStatus.MEMBER_REPRESENTATIVE_EMPTY);
@@ -263,7 +261,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
             throw new AuthHandler(ErrorStatus.MEMBER_OPEN_DATE_EMPTY);
         if (request.getBank() == null)
             throw new AuthHandler(ErrorStatus.MEMBER_BANK_EMPTY);
-        if (request.getAccountNum() == null)
+        if (request.getAccountNumber() == null)
             throw new AuthHandler(ErrorStatus.MEMBER_ACCOUNT_NUM_EMPTY);
         if (request.getAccountHolder() == null)
             throw new AuthHandler(ErrorStatus.MEMBER_ACCOUNT_HOLDER_EMPTY);

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
@@ -57,8 +57,6 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     @Override
     @Transactional
     public Member joinMember(AuthRequestDTO.JoinDTO request){
-        if (!(Role.of(request.getRole()).equals(Role.BOSS) || Role.of(request.getRole()).equals(Role.TEACHER)))
-            throw new AuthHandler(ErrorStatus.MEMBER_ROLE_INVALID);
         if (memberRepository.existsByEmailAndStatus(request.getEmail(), Status.ACTIVE))
             throw new AuthHandler(ErrorStatus.MEMBER_EMAIL_DUPLICATE);
         if (memberRepository.existsByPhoneAndStatus(request.getPhone(), Status.ACTIVE))
@@ -244,8 +242,6 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         Member newMember = AuthConverter.toSocialMember(request, socialType);
         passwordUtil.setSocialMemberPassword(newMember);
 
-        if (!(Role.of(request.getRole()).equals(Role.BOSS) || Role.of(request.getRole()).equals(Role.TEACHER)))
-            throw new AuthHandler(ErrorStatus.MEMBER_ROLE_INVALID);
         if (memberRepository.existsByNicknameAndStatus(request.getNickname(), Status.ACTIVE))
             throw new AuthHandler(ErrorStatus.MEMBER_NICKNAME_DUPLICATE);
 
@@ -255,12 +251,14 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         return memberRepository.save(newMember);
     }
 
-    private void enterBossInfo(AuthRequestDTO.JoinCommonDTO request, Member member) {
+    @Override
+    public void enterBossInfo(AuthRequestDTO.JoinCommonDTO request, Member member) {
         member.setProfile(request.getNickname(), request.getProfileImg());
     }
 
+    @Override
     @Transactional
-    private void enterTeacherInfo(AuthRequestDTO.JoinCommonDTO request, Member member) {
+    public void enterTeacherInfo(AuthRequestDTO.JoinCommonDTO request, Member member) {
         // TODO : 사업자 인증 여부 확인 로직 추가
 
         if (request.getBusinessNum() == null)
@@ -269,6 +267,12 @@ public class AuthCommandServiceImpl implements AuthCommandService {
             throw new AuthHandler(ErrorStatus.MEMBER_REPRESENTATIVE_EMPTY);
         if (request.getOpenDate() == null || request.getOpenDate().toString().isEmpty())
             throw new AuthHandler(ErrorStatus.MEMBER_OPEN_DATE_EMPTY);
+        if (request.getBank() == null)
+            throw new AuthHandler(ErrorStatus.MEMBER_BANK_EMPTY);
+        if (request.getAccountNum() == null)
+            throw new AuthHandler(ErrorStatus.MEMBER_ACCOUNT_NUM_EMPTY);
+        if (request.getAccountHolder() == null)
+            throw new AuthHandler(ErrorStatus.MEMBER_ACCOUNT_HOLDER_EMPTY);
         if (request.getField() == null)
             throw new AuthHandler(ErrorStatus.MEMBER_FIELD_EMPTY);
         if (request.getCareer() == null)

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthQueryService.java
@@ -1,4 +1,7 @@
 package kr.co.teacherforboss.service.authService;
 
+import kr.co.teacherforboss.web.dto.AuthRequestDTO;
+
 public interface AuthQueryService {
+    boolean checkNickname(AuthRequestDTO.CheckNicknameDTO request);
 }

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthQueryServiceImpl.java
@@ -4,7 +4,9 @@ import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
 import kr.co.teacherforboss.apiPayload.exception.handler.AuthHandler;
 import kr.co.teacherforboss.config.jwt.PrincipalDetails;
 import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.enums.Status;
 import kr.co.teacherforboss.repository.MemberRepository;
+import kr.co.teacherforboss.web.dto.AuthRequestDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -26,5 +28,10 @@ public class AuthQueryServiceImpl implements AuthQueryService, UserDetailsServic
 
         log.info("user Email [ID : {}]", member.getEmail());
         return new PrincipalDetails(member);
+    }
+
+    @Override
+    public boolean checkNickname(AuthRequestDTO.CheckNicknameDTO request) {
+        return !memberRepository.existsByNicknameAndStatus(request.getNickname(), Status.ACTIVE);
     }
 }

--- a/src/main/java/kr/co/teacherforboss/util/PasswordUtil.java
+++ b/src/main/java/kr/co/teacherforboss/util/PasswordUtil.java
@@ -6,6 +6,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -13,10 +15,13 @@ public class PasswordUtil {
 
     private final PasswordEncoder passwordEncoder;
 
-    public void setMemberPassword(Member member, String password) {
+    public List<String> generatePassword(String password) {
+        List<String> passwordList = new ArrayList<>();
         String pwSalt = generateSalt();
         String pwHash = generatePwHash(password, pwSalt);
-        member.setPassword(pwSalt, pwHash);
+        passwordList.add(pwSalt);
+        passwordList.add(pwHash);
+        return passwordList;
     }
 
     // hash 생성
@@ -40,10 +45,13 @@ public class PasswordUtil {
         return sb.toString();
     }
 
-    public void setSocialMemberPassword(Member member){
+    public List<String> generateSocialMemberPassword(){
+        List<String> passwordList = new ArrayList<>();
         String pwSalt = generateSalt();
         String pwHash = generatePwHash(getRandomPassword(20), pwSalt);
-        member.setPassword(pwSalt, pwHash);
+        passwordList.add(pwSalt);
+        passwordList.add(pwHash);
+        return passwordList;
     }
 
     private static final char[] rndAllCharacters = new char[]{

--- a/src/main/java/kr/co/teacherforboss/validation/annotation/CheckRole.java
+++ b/src/main/java/kr/co/teacherforboss/validation/annotation/CheckRole.java
@@ -1,0 +1,21 @@
+package kr.co.teacherforboss.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import kr.co.teacherforboss.validation.validator.CheckRoleValidator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = CheckRoleValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckRole {
+    String message() default "유효하지 않은 역할 값입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/kr/co/teacherforboss/validation/validator/CheckRoleValidator.java
+++ b/src/main/java/kr/co/teacherforboss/validation/validator/CheckRoleValidator.java
@@ -1,0 +1,35 @@
+package kr.co.teacherforboss.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
+import kr.co.teacherforboss.domain.enums.Purpose;
+import kr.co.teacherforboss.domain.enums.Role;
+import kr.co.teacherforboss.validation.annotation.CheckRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CheckRoleValidator implements ConstraintValidator<CheckRole, Integer> {
+
+    private String message;
+
+    @Override
+    public void initialize(CheckRole constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.message = constraintAnnotation.message();
+    }
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        boolean isValid = Role.of(value).equals(Role.BOSS) || Role.of(value).equals(Role.TEACHER);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/web/controller/AuthController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/AuthController.java
@@ -10,6 +10,7 @@ import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.EmailAuth;
 import kr.co.teacherforboss.domain.PhoneAuth;
 import kr.co.teacherforboss.service.authService.AuthCommandService;
+import kr.co.teacherforboss.service.authService.AuthQueryService;
 import kr.co.teacherforboss.validation.annotation.CheckSocialType;
 import kr.co.teacherforboss.validation.annotation.ExistPrincipalDetails;
 import kr.co.teacherforboss.web.dto.AuthRequestDTO;
@@ -34,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthCommandService authCommandService;
+    private final AuthQueryService authQueryService;
     private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/signup")
@@ -112,5 +114,11 @@ public class AuthController {
         Member member = authCommandService.socialLogin(request, socialType);
         AuthResponseDTO.TokenResponseDTO tokenResponseDTO = jwtTokenProvider.createTokenResponse(member.getEmail(), member.getName(), member.getRole());
         return ApiResponse.onSuccess(tokenResponseDTO);
+    }
+
+    @PostMapping("/nickname/check")
+    public ApiResponse<AuthResponseDTO.CheckNicknameResultDTO> checkNickname(@RequestBody @Valid AuthRequestDTO.CheckNicknameDTO request) {
+        Boolean nicknameCheck = authQueryService.checkNickname(request);
+        return ApiResponse.onSuccess(AuthConverter.toCheckNicknameDTO(nicknameCheck));
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -15,12 +15,50 @@ import java.time.LocalDate;
 
 public class AuthRequestDTO {
     @Getter
-    @Builder
-    public static class JoinDTO{
-        @Email
-        @NotNull
+    public static abstract class JoinCommonDTO{
+        @NotNull(message = "보스(1)/티쳐(2) 중 선택해주세요.")
+        Integer role;
+
+        @Email(message = "이메일 형식이 아닙니다.")
+        @NotNull(message = "이메일이 없습니다.")
         String email;
 
+        @NotNull(message = "이름이 없습니다.")
+        String name;
+
+        @NotNull(message = "닉네임을 입력해주세요.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]{1,10}$", message = "닉네임은 한국어/영어/숫자로 최대 10자 입력 가능합니다.")
+        String nickname;
+
+        @NotNull(message = "전화번호가 없습니다.")
+        @Pattern(regexp = "010([2-9])\\d{7,8}", message = "전화번호는 10 ~ 11 자리의 숫자만 입력 가능합니다.")
+        String phone;
+
+        Integer gender;
+
+        LocalDate birthDate;
+
+        @NotNull(message = "프로필 이미지를 선택해주세요.")
+        String profileImg;
+
+        String businessNum;
+
+        String representative;
+
+        LocalDate openDate;
+
+        String field;
+
+        Integer career;
+
+        String introduction;
+
+        String keywords;
+    }
+
+    @Getter
+    @Builder
+    public static class JoinDTO extends JoinCommonDTO{
         @NotNull
         Long emailAuthId;
 
@@ -34,17 +72,6 @@ public class AuthRequestDTO {
 
         @NotNull
         String rePassword;
-
-        @NotNull
-        String name;
-
-        @NotNull
-        @Pattern(regexp = "010([2-9])\\d{7,8}", message = "전화번호는 10 ~ 11 자리의 숫자만 입력 가능합니다.")
-        String phone;
-
-        Integer gender;
-
-        LocalDate birthDate;
 
         @NotNull(message = "이용 정보 약관 동의는 필수여야 합니다.")
         @CheckTrueOrFalse
@@ -160,23 +187,7 @@ public class AuthRequestDTO {
 
     @Getter
     @Builder
-    public static class SocialLoginDTO {
+    public static class SocialLoginDTO extends JoinCommonDTO{
 
-        @Email(message = "이메일 형식이 아닙니다.")
-        @NotNull(message = "이메일이 없습니다.")
-        String email;
-
-        @NotNull(message = "이름이 없습니다.")
-        String name;
-
-        @NotNull(message = "전화번호가 없습니다.")
-        @Pattern(regexp = "010([2-9])\\d{7,8}", message = "전화번호는 10 ~ 11 자리의 숫자만 입력 가능합니다.")
-        String phone;
-
-        Integer gender;
-
-        LocalDate birthDate;
-
-        String profileImg;
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -54,6 +54,12 @@ public class AuthRequestDTO {
         String introduction;
 
         String keywords;
+
+        String bank;
+
+        String accountNum;
+
+        String accountHolder;
     }
 
     @Getter

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -190,4 +190,12 @@ public class AuthRequestDTO {
     public static class SocialLoginDTO extends JoinCommonDTO{
 
     }
+
+    @Getter
+    @Jacksonized
+    @Builder
+    public static class CheckNicknameDTO {
+        @NotNull(message = "닉네임을 입력해주세요.")
+        String nickname;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -46,7 +46,7 @@ public class AuthRequestDTO {
         String profileImg;
 
         @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "사업자 등록 번호는 최대 10자 이내로 입력 가능합니다.")
-        String businessNum;
+        String businessNumber;
 
         @Size(max = 20, message = "대표자명은 최대 20자 이내로 입력 가능합니다.")
         String representative;
@@ -67,7 +67,7 @@ public class AuthRequestDTO {
 
         String bank;
 
-        String accountNum;
+        String accountNumber;
 
         String accountHolder;
     }

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -1,5 +1,6 @@
 package kr.co.teacherforboss.web.dto;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import kr.co.teacherforboss.validation.annotation.CheckPurpose;
 import jakarta.validation.constraints.Email;
@@ -13,6 +14,7 @@ import lombok.Getter;
 import lombok.extern.jackson.Jacksonized;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class AuthRequestDTO {
     @Getter
@@ -25,7 +27,7 @@ public class AuthRequestDTO {
         @NotNull(message = "이메일이 없습니다.")
         String email;
 
-        @NotNull(message = "이름이 없습니다.")
+        @NotBlank(message = "이름이 없습니다.")
         String name;
 
         @NotNull(message = "닉네임을 입력해주세요.")
@@ -43,19 +45,25 @@ public class AuthRequestDTO {
         @NotNull(message = "프로필 이미지를 선택해주세요.")
         String profileImg;
 
+        @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "사업자 등록 번호는 최대 10자 이내로 입력 가능합니다.")
         String businessNum;
 
+        @Size(max = 20, message = "대표자명은 최대 20자 이내로 입력 가능합니다.")
         String representative;
 
         LocalDate openDate;
 
+        @Size(max = 20, message = "분야는 최대 20자 이내로 입력 가능합니다.")
         String field;
 
+        @Max(value = 2, message = "경력은 십의 자리 수 이내로 입력 가능합니다.")
         Integer career;
 
+        @Size(max = 40, message = "한 줄 소개는 최대 40자 이내로 입력 가능합니다.")
         String introduction;
 
-        String keywords;
+        @Size(max = 5)
+        List<String> keywords;
 
         String bank;
 

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import kr.co.teacherforboss.validation.annotation.CheckRole;
 import kr.co.teacherforboss.validation.annotation.CheckTrueOrFalse;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +17,7 @@ import java.time.LocalDate;
 public class AuthRequestDTO {
     @Getter
     public static abstract class JoinCommonDTO{
+        @CheckRole
         @NotNull(message = "보스(1)/티쳐(2) 중 선택해주세요.")
         Integer role;
 

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthResponseDTO.java
@@ -97,4 +97,12 @@ public class AuthResponseDTO {
         String email;
         LocalDateTime createdAt;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CheckNicknameResultDTO {
+        boolean nicknameCheck;
+    }
 }

--- a/src/test/java/kr/co/teacherforboss/util/AuthTestUtil.java
+++ b/src/test/java/kr/co/teacherforboss/util/AuthTestUtil.java
@@ -30,7 +30,7 @@ public class AuthTestUtil {
                 .name("백채연")
                 .email("email@gmail.com")
                 .loginType(LoginType.GENERAL)
-                .role(Role.USER)
+                .role(Role.BOSS)
                 .birthDate(LocalDate.parse("2000-04-22", formatter))
                 .gender(Gender.FEMALE)
                 .phone("01012341234")


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #142 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/77263479/1b116ee7-bc2e-43ae-a2b8-f4bec6d622e6)
- Member 엔티티 nickname 필드 추가
- TeacherInfo 엔티티 생성
- 사용자 역할 생성에 따라 Role Enum 수정 (BOSS:1/TEACHER:2/ADMIN)
- 티쳐 레벨 관리하는 Level Enum 생성
- 닉네임 중복 검증 API 추가 (AuthQueryService)
- 회원가입, 소셜로그인 로직 추가 (AuthCommandService)
- 회원가입, 소셜로그인의 공통되는 필드 묶어서 JoinCommonDTO 추상 클래스 생성 후 각각 상속받는 JoinDTO와 SocialLoginDTO로 수정
- RequestBody로 전달되는 Role 값을 검증하는 커스텀 어노테이션 CheckRole 생성

일반 회원가입 로직 (_**보스/티쳐선택** -> 기존 회원가입 -> **새로 추가된 프로필 설정 부분 후 찐 가입 완료!!**_) 로직과 소셜로그인 로직 (_기존 소셜로그인 -> **보스/티쳐 선택** -> **새로 추가된 프로필 설정 부분 후 찐 가입 완료!!**_) 흐름에 따라 코드 추가했습니당. 
두 기능 모두 공통되는 부분이 볼드체 처리한 부분인데, 보스/티쳐 선택의 경우 DTO에 커스텀 어노테이션 CheckRole로 검증했고, 새로 추가된 프로필 설정에 경우 보스와 티쳐의 따라 케이스가 다르기에 따로 메서드 분기 처리했습니다! 



**😶‍🌫️로직을 구현하며 써내려간 고민의 흔적들 ... (귀찮으면 안읽어도 됨)**

![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/77263479/befb7de9-bbc9-4306-8c7d-dfda1a0e075e)
1. 처음엔 이렇게 role 타입에 따라 boss, teacher 나눠서 분기 처리 진행했습니다. 그런데 이런 경우 일반 회원가입 DTO와 소셜로그인 DTO 구조가 다르기에 메서드의 파라미터가 제한적이라 일반 회원가입할 때만 사용 가능합니다. 그래서 추가 프로필을 입력하는 하나의 메서드로 빼기보단, 보스와 티쳐에 따라 정보 저장할 수 있는 각기 메서드로 만드는 게 용이하다고 판단했습니당

![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/77263479/c15e4b39-ccd7-47cf-b06a-8e215dd819e9)
2. 그래서 이렇게 보스/티쳐 따로 각각 메서드마다 어느 request가 와도 파라미터 다 받아들일 수 있도록 했는데, 이런 경우 긴 파라미터를 일일이 하나씩 다 써줘야 한다는 불편함이 있고, 저희 객사오에서 배웠던... 역할에 따라 책임을 수행할 때 다른 객체가 모르게끔,, 알아서 처리하게 하라... 라는 글 내용이 기억나서 객체지향스럽지 않다고 생각했습니다 하하
3. 해서 결론적으로 생각한게 현재 코드입니다! 일반 회원가입과 소셜로그인의 공통된 필드를 추상 클래스로 빼고, 각기 상속받은 클래스를 따로 생성해준 뒤, DTO 타입 (role 구분)에 따라 해당되는 메서드를 사용할 수 있도록 제작했습니다!


## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

기획상 누락된 부분이 있거나 코드 로직에 수정할 부분이 있다면 댓글 달아주세요!
