### PR TITLE
✨[FEAT] 보스톡 게시글 작성/상세 조회

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -105,6 +105,9 @@ public enum ErrorStatus implements BaseErrorCode {
     EXAM_CATEGORY_NOT_FOUND(NOT_FOUND, "EXAM4047", "시험 카테고리가 존재하지 않습니다."),
     EXAM_TAG_NOT_FOUND(NOT_FOUND, "EXAM4048", "시험 카테고리가 존재하지 않습니다."),
 
+    // Board
+    POST_NOT_FOUND(NOT_FOUND, "BOARD4041", "게시물을 찾을 수 없습니다."),
+
     // For test
     TEMP_EXCEPTION(BAD_REQUEST, "TEMP4001", "이거는 테스트");
 

--- a/src/main/java/kr/co/teacherforboss/apiPayload/exception/handler/BoardHandler.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/exception/handler/BoardHandler.java
@@ -1,0 +1,11 @@
+package kr.co.teacherforboss.apiPayload.exception.handler;
+
+import kr.co.teacherforboss.apiPayload.code.BaseErrorCode;
+import kr.co.teacherforboss.apiPayload.exception.GeneralException;
+
+public class BoardHandler extends GeneralException {
+
+    public BoardHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
@@ -1,0 +1,78 @@
+package kr.co.teacherforboss.converter;
+
+import kr.co.teacherforboss.domain.Hashtag;
+import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.Post;
+import kr.co.teacherforboss.domain.PostHashtag;
+import kr.co.teacherforboss.web.dto.BoardRequestDTO;
+import kr.co.teacherforboss.web.dto.BoardResponseDTO;
+
+import java.util.List;
+
+public class BoardConverter {
+
+    public static BoardResponseDTO.SavePostDTO toSavePostDTO(Post post) {
+        return BoardResponseDTO.SavePostDTO.builder()
+                .postId(post.getId())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+
+    public static BoardResponseDTO.GetPostDTO toGetPostDTO(Post post, List<String> hashtagList, String postLike, String postBookmark) {;
+        return BoardResponseDTO.GetPostDTO.builder()
+                .title(post.getTitle())
+                .content(post.getContent())
+                .hashtagList(hashtagList)
+                .likeCount(post.getLikeCount())
+                .memberInfo(toMemberInfo(post.getMember()))
+                .bookmarkCount(post.getBookmarkCount())
+                .createdAt(post.getCreatedAt())
+                .like(postLike)
+                .bookmark(postBookmark)
+                .build();
+    }
+
+    public static BoardResponseDTO.MemberInfo toMemberInfo(Member member) {
+        return BoardResponseDTO.MemberInfo.builder()
+                .memberId(member.getId())
+                .name(member.getName())
+                .profileImg(member.getProfileImg())
+                .build();
+    }
+
+    public static Post toPost(BoardRequestDTO.SavePostDTO request, Member member) {
+        String imageUrlList = null;
+        if (request.getImageUrlList() != null) {
+            imageUrlList = String.join(";", request.getImageUrlList());
+        }
+        return Post.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .member(member)
+                .imageUrl(imageUrlList)
+                .likeCount(0)
+                .bookmarkCount(0)
+                .viewCount(0)
+                .build();
+    }
+
+    public static Hashtag toHashtag(String hashtag) {
+        return Hashtag.builder()
+                .name(hashtag)
+                .build();
+    }
+
+    public static PostHashtag toPostHashtag(Post post, Hashtag hashtag) {
+        return PostHashtag.builder()
+                .post(post)
+                .hashtag(hashtag)
+                .build();
+    }
+
+    public static List<String> toPostHashtagList(Post post) {
+        return post.getHashtagList()
+                .stream().map(hashtag ->
+                        hashtag.getHashtag().getName())
+                .toList();
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
@@ -18,7 +18,7 @@ public class BoardConverter {
                 .build();
     }
 
-    public static BoardResponseDTO.GetPostDTO toGetPostDTO(Post post, List<String> hashtagList, String postLike, String postBookmark) {;
+    public static BoardResponseDTO.GetPostDTO toGetPostDTO(Post post, List<String> hashtagList, String liked, String bookmarked) {;
         return BoardResponseDTO.GetPostDTO.builder()
                 .title(post.getTitle())
                 .content(post.getContent())
@@ -27,8 +27,8 @@ public class BoardConverter {
                 .memberInfo(toMemberInfo(post.getMember()))
                 .bookmarkCount(post.getBookmarkCount())
                 .createdAt(post.getCreatedAt())
-                .like(postLike)
-                .bookmark(postBookmark)
+                .liked(liked)
+                .bookmarked(bookmarked)
                 .build();
     }
 

--- a/src/main/java/kr/co/teacherforboss/domain/Hashtag.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Hashtag.java
@@ -1,0 +1,22 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.validation.constraints.NotNull;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Hashtag extends BaseEntity {
+    @NotNull
+    @Column(length = 10)
+    private String name;
+}

--- a/src/main/java/kr/co/teacherforboss/domain/Post.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Post.java
@@ -1,0 +1,59 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.validation.constraints.NotNull;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Post extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId")
+    private Member member;
+
+    @NotNull
+    @Column(length = 30)
+    private String title;
+
+    @NotNull
+    @Column(length = 1000)
+    private String content;
+
+    @NotNull
+    @Column
+    @ColumnDefault("0")
+    private Integer likeCount;
+
+    @NotNull
+    @Column
+    @ColumnDefault("0")
+    private Integer viewCount;
+
+    @NotNull
+    @Column
+    @ColumnDefault("0")
+    private Integer bookmarkCount;
+
+    @Column
+    private String imageUrl;
+
+    @OneToMany(mappedBy = "post")
+    private List<PostHashtag> hashtagList;
+}

--- a/src/main/java/kr/co/teacherforboss/domain/PostBookmark.java
+++ b/src/main/java/kr/co/teacherforboss/domain/PostBookmark.java
@@ -33,5 +33,5 @@ public class PostBookmark extends BaseEntity {
     @NotNull
     @Enumerated(EnumType.STRING)
     @ColumnDefault("'F'")
-    private BooleanType bookmark;
+    private BooleanType bookmarked;
 }

--- a/src/main/java/kr/co/teacherforboss/domain/PostBookmark.java
+++ b/src/main/java/kr/co/teacherforboss/domain/PostBookmark.java
@@ -1,0 +1,37 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import kr.co.teacherforboss.domain.enums.BooleanType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PostBookmark extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "postId")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId")
+    private Member member;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'F'")
+    private BooleanType bookmark;
+}

--- a/src/main/java/kr/co/teacherforboss/domain/PostHashtag.java
+++ b/src/main/java/kr/co/teacherforboss/domain/PostHashtag.java
@@ -1,0 +1,27 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PostHashtag extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "postId")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hashtagId")
+    private Hashtag hashtag;
+}

--- a/src/main/java/kr/co/teacherforboss/domain/PostLike.java
+++ b/src/main/java/kr/co/teacherforboss/domain/PostLike.java
@@ -1,0 +1,37 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import kr.co.teacherforboss.domain.enums.BooleanType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PostLike extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "postId")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId")
+    private Member member;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'F'")
+    private BooleanType postlike;
+}

--- a/src/main/java/kr/co/teacherforboss/domain/PostLike.java
+++ b/src/main/java/kr/co/teacherforboss/domain/PostLike.java
@@ -33,5 +33,5 @@ public class PostLike extends BaseEntity {
     @NotNull
     @Enumerated(EnumType.STRING)
     @ColumnDefault("'F'")
-    private BooleanType postlike;
+    private BooleanType liked;
 }

--- a/src/main/java/kr/co/teacherforboss/repository/HashtagRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/HashtagRepository.java
@@ -1,0 +1,14 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.Hashtag;
+import kr.co.teacherforboss.domain.enums.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+    boolean existsByNameAndStatus(String name, Status status);
+    Hashtag findByNameAndStatus(String name, Status status);
+}

--- a/src/main/java/kr/co/teacherforboss/repository/PostBookmarkRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/PostBookmarkRepository.java
@@ -1,0 +1,14 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.Post;
+import kr.co.teacherforboss.domain.PostBookmark;
+import kr.co.teacherforboss.domain.enums.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostBookmarkRepository extends JpaRepository<PostBookmark, Long> {
+    Boolean existsByPostAndMemberAndStatus(Post post, Member member, Status status);
+    PostBookmark findByPostAndMemberAndStatus(Post post, Member member, Status status);
+}

--- a/src/main/java/kr/co/teacherforboss/repository/PostHashtagRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/PostHashtagRepository.java
@@ -1,0 +1,10 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.PostHashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
+
+}

--- a/src/main/java/kr/co/teacherforboss/repository/PostLikeRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/PostLikeRepository.java
@@ -1,0 +1,14 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.Post;
+import kr.co.teacherforboss.domain.PostLike;
+import kr.co.teacherforboss.domain.enums.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    Boolean existsByPostAndMemberAndStatus(Post post, Member member, Status status);
+    PostLike findByPostAndMemberAndStatus(Post post, Member member, Status status);
+}

--- a/src/main/java/kr/co/teacherforboss/repository/PostRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/PostRepository.java
@@ -1,0 +1,13 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.Post;
+import kr.co.teacherforboss.domain.enums.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+    Optional<Post> findByIdAndStatus(Long postId, Status status);
+}

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandService.java
@@ -1,0 +1,8 @@
+package kr.co.teacherforboss.service.boardService;
+
+import kr.co.teacherforboss.domain.Post;
+import kr.co.teacherforboss.web.dto.BoardRequestDTO;
+
+public interface BoardCommandService {
+    Post savePost(BoardRequestDTO.SavePostDTO request);
+}

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
@@ -1,0 +1,53 @@
+package kr.co.teacherforboss.service.boardService;
+
+import kr.co.teacherforboss.converter.BoardConverter;
+import kr.co.teacherforboss.domain.Hashtag;
+import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.Post;
+import kr.co.teacherforboss.domain.PostHashtag;
+import kr.co.teacherforboss.domain.enums.Status;
+import kr.co.teacherforboss.repository.HashtagRepository;
+import kr.co.teacherforboss.repository.PostHashtagRepository;
+import kr.co.teacherforboss.repository.PostRepository;
+import kr.co.teacherforboss.service.authService.AuthCommandService;
+import kr.co.teacherforboss.web.dto.BoardRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BoardCommandServiceImpl implements BoardCommandService{
+    private final AuthCommandService authCommandService;
+    private final PostRepository postRepository;
+    private final HashtagRepository hashtagRepository;
+    private final PostHashtagRepository postHashtagRepository;
+
+    @Override
+    @Transactional
+    public Post savePost(BoardRequestDTO.SavePostDTO request) {
+        Member member = authCommandService.getMember();
+        Post post = BoardConverter.toPost(request, member);
+        List<PostHashtag> postHashtags = new ArrayList<>();
+        // TODO: 유저가 동시에 같은 해시태그 값을 저장하면?
+        if (request.getHashtagList() != null) {
+            for (String tag : request.getHashtagList()) {
+                Hashtag hashtag;
+                if (hashtagRepository.existsByNameAndStatus(tag, Status.ACTIVE)) {
+                    hashtag = hashtagRepository.findByNameAndStatus(tag, Status.ACTIVE);
+                } else {
+                    hashtag = BoardConverter.toHashtag(tag);
+                    hashtagRepository.save(hashtag);
+                }
+                PostHashtag postHashtag = BoardConverter.toPostHashtag(post, hashtag);
+                postHashtags.add(postHashtag);
+            }
+        }
+        postRepository.save(post);
+        postHashtagRepository.saveAll(postHashtags);
+        return post;
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
@@ -16,11 +16,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
-public class BoardCommandServiceImpl implements BoardCommandService{
+public class BoardCommandServiceImpl implements BoardCommandService {
     private final AuthCommandService authCommandService;
     private final PostRepository postRepository;
     private final HashtagRepository hashtagRepository;
@@ -34,13 +36,11 @@ public class BoardCommandServiceImpl implements BoardCommandService{
         List<PostHashtag> postHashtags = new ArrayList<>();
         // TODO: 유저가 동시에 같은 해시태그 값을 저장하면?
         if (request.getHashtagList() != null) {
-            for (String tag : request.getHashtagList()) {
-                Hashtag hashtag;
-                if (hashtagRepository.existsByNameAndStatus(tag, Status.ACTIVE)) {
-                    hashtag = hashtagRepository.findByNameAndStatus(tag, Status.ACTIVE);
-                } else {
-                    hashtag = BoardConverter.toHashtag(tag);
-                    hashtagRepository.save(hashtag);
+            Set<String> uniqueHashtags = new HashSet<>(request.getHashtagList());
+            for (String tag : uniqueHashtags) {
+                Hashtag hashtag = hashtagRepository.findByNameAndStatus(tag, Status.ACTIVE);
+                if (hashtag == null) {
+                    hashtag = hashtagRepository.save(BoardConverter.toHashtag(tag));
                 }
                 PostHashtag postHashtag = BoardConverter.toPostHashtag(post, hashtag);
                 postHashtags.add(postHashtag);

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardQueryService.java
@@ -1,0 +1,7 @@
+package kr.co.teacherforboss.service.boardService;
+
+import kr.co.teacherforboss.web.dto.BoardResponseDTO;
+
+public interface BoardQueryService {
+    BoardResponseDTO.GetPostDTO getPost(Long postId);
+}

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardQueryServiceImpl.java
@@ -5,6 +5,8 @@ import kr.co.teacherforboss.apiPayload.exception.handler.BoardHandler;
 import kr.co.teacherforboss.converter.BoardConverter;
 import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.Post;
+import kr.co.teacherforboss.domain.PostBookmark;
+import kr.co.teacherforboss.domain.PostLike;
 import kr.co.teacherforboss.domain.enums.Status;
 import kr.co.teacherforboss.repository.PostBookmarkRepository;
 import kr.co.teacherforboss.repository.PostLikeRepository;
@@ -33,20 +35,23 @@ public class BoardQueryServiceImpl implements BoardQueryService {
         Post post = postRepository.findByIdAndStatus(postId, Status.ACTIVE)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.POST_NOT_FOUND));
 
-        String postLike = "F";
-        String postBookmark = "F";
+        String liked = "F";
+        String bookmarked = "F";
         List<String> hashtagList = null;
 
-        if (postLikeRepository.existsByPostAndMemberAndStatus(post, member, Status.ACTIVE)) {
-            postLike = String.valueOf(postLikeRepository.findByPostAndMemberAndStatus(post, member, Status.ACTIVE).getPostlike());
-        }
-        if (postBookmarkRepository.existsByPostAndMemberAndStatus(post, member, Status.ACTIVE)) {
-            postBookmark = String.valueOf(postBookmarkRepository.findByPostAndMemberAndStatus(post, member, Status.ACTIVE).getBookmark());
+        PostLike postLike = postLikeRepository.findByPostAndMemberAndStatus(post, member, Status.ACTIVE);
+        if (postLike != null) {
+            liked = String.valueOf(postLike.getLiked());
         }
 
+        PostBookmark postBookmark = postBookmarkRepository.findByPostAndMemberAndStatus(post, member, Status.ACTIVE);
+        if (postBookmark != null) {
+            bookmarked = String.valueOf(postBookmark.getBookmarked());
+        }
         if (!post.getHashtagList().isEmpty()) {
             hashtagList = BoardConverter.toPostHashtagList(post);
         }
-        return BoardConverter.toGetPostDTO(post, hashtagList, postLike, postBookmark);
+
+        return BoardConverter.toGetPostDTO(post, hashtagList, liked, bookmarked);
     }
 }

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardQueryServiceImpl.java
@@ -1,0 +1,52 @@
+package kr.co.teacherforboss.service.boardService;
+
+import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
+import kr.co.teacherforboss.apiPayload.exception.handler.BoardHandler;
+import kr.co.teacherforboss.converter.BoardConverter;
+import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.Post;
+import kr.co.teacherforboss.domain.enums.Status;
+import kr.co.teacherforboss.repository.PostBookmarkRepository;
+import kr.co.teacherforboss.repository.PostLikeRepository;
+import kr.co.teacherforboss.repository.PostRepository;
+import kr.co.teacherforboss.service.authService.AuthCommandService;
+import kr.co.teacherforboss.web.dto.BoardResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BoardQueryServiceImpl implements BoardQueryService {
+
+    private final AuthCommandService authCommandService;
+    private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
+    private final PostBookmarkRepository postBookmarkRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public BoardResponseDTO.GetPostDTO getPost(Long postId) {
+        Member member = authCommandService.getMember();
+        Post post = postRepository.findByIdAndStatus(postId, Status.ACTIVE)
+                .orElseThrow(() -> new BoardHandler(ErrorStatus.POST_NOT_FOUND));
+
+        String postLike = "F";
+        String postBookmark = "F";
+        List<String> hashtagList = null;
+
+        if (postLikeRepository.existsByPostAndMemberAndStatus(post, member, Status.ACTIVE)) {
+            postLike = String.valueOf(postLikeRepository.findByPostAndMemberAndStatus(post, member, Status.ACTIVE).getPostlike());
+        }
+        if (postBookmarkRepository.existsByPostAndMemberAndStatus(post, member, Status.ACTIVE)) {
+            postBookmark = String.valueOf(postBookmarkRepository.findByPostAndMemberAndStatus(post, member, Status.ACTIVE).getBookmark());
+        }
+
+        if (!post.getHashtagList().isEmpty()) {
+            hashtagList = BoardConverter.toPostHashtagList(post);
+        }
+        return BoardConverter.toGetPostDTO(post, hashtagList, postLike, postBookmark);
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/web/controller/BoardController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/BoardController.java
@@ -1,0 +1,41 @@
+package kr.co.teacherforboss.web.controller;
+
+import jakarta.validation.Valid;
+import kr.co.teacherforboss.apiPayload.ApiResponse;
+import kr.co.teacherforboss.converter.BoardConverter;
+import kr.co.teacherforboss.domain.Post;
+import kr.co.teacherforboss.service.boardService.BoardCommandService;
+import kr.co.teacherforboss.service.boardService.BoardQueryService;
+import kr.co.teacherforboss.web.dto.BoardRequestDTO;
+import kr.co.teacherforboss.web.dto.BoardResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Validated
+@RestController
+@RequestMapping("api/v1/board")
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final BoardCommandService boardCommandService;
+    private final BoardQueryService boardQueryService;
+
+    @PostMapping("/boss/posts")
+    public ApiResponse<BoardResponseDTO.SavePostDTO> savePost(@RequestBody @Valid BoardRequestDTO.SavePostDTO request){
+        Post post = boardCommandService.savePost(request);
+        return ApiResponse.onSuccess(BoardConverter.toSavePostDTO(post));
+    }
+
+    @GetMapping("/boss/posts/{postId}")
+    public ApiResponse<BoardResponseDTO.GetPostDTO> getPost(@PathVariable("postId") Long postId){
+        return ApiResponse.onSuccess(boardQueryService.getPost(postId));
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/web/dto/BoardRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/BoardRequestDTO.java
@@ -1,0 +1,33 @@
+package kr.co.teacherforboss.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class BoardRequestDTO {
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class SavePostDTO{
+
+        @NotNull(message = "제목은 필수 입력값입니다.")
+        @Size(max = 30, message = "제목은 최대 30자 입력 가능합니다.")
+        String title;
+
+        @NotNull(message = "게시물 내용은 필수 입력값입니다.")
+        @Size(max = 1000, message = "게시물 내용은 최대 1000자 입력 가능합니다.")
+        String content;
+
+        @Size(max = 3, message = "사진은 최대 3장까지 등록 가능합니다.")
+        List<String> imageUrlList;
+
+        @Size(max = 5, message = "해시태그는 최대 5개까지 등록 가능합니다.")
+        List<String> hashtagList;
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
@@ -26,8 +26,8 @@ public class BoardResponseDTO {
         String content;
         List<String> hashtagList;
         MemberInfo memberInfo;
-        String like;
-        String bookmark;
+        String liked;
+        String bookmarked;
         Integer likeCount;
         Integer bookmarkCount;
         LocalDateTime createdAt;

--- a/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
@@ -1,0 +1,45 @@
+package kr.co.teacherforboss.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class BoardResponseDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SavePostDTO {
+        Long postId;
+        LocalDateTime createdAt;
+    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetPostDTO{
+        String title;
+        String content;
+        List<String> hashtagList;
+        MemberInfo memberInfo;
+        String like;
+        String bookmark;
+        Integer likeCount;
+        Integer bookmarkCount;
+        LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberInfo {
+        Long memberId;
+        String name;
+        String profileImg;
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #155 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/77263479/df450bd9-6a3f-44dd-bfce-8a61a55de5ad)
**보스톡 게시물 작성**

![image](https://github.com/teacher-for-boss/teacher-for-boss-server/assets/77263479/d6967f97-a726-43d7-92ee-d695d1959973)
**보스톡 게시물 상세 조회**

- Hashtag, Post, PostBookmark, PostHashtag, PostLike 엔티티 추가
- 보스톡 게시물 작성 API 제작
- 보스톡 게시물 상세 조회 API 제작

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)
**보스톡 게시물 작성**
- requestBody valid 진행

**보스톡 게시물 상세 조회**
- postId 값에 따라 게시물 존재 여부 검증

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- imageUrl 컬럼 크기 정해야하는데 우선 임시로 정해두지 않았습니다
- 유저가 해시태그 리스트 입력 중 중복된 값들을 (ex "해시태그1", "해시태그1") 입력할 때 예외 검증 필요할까요?
- **보스톡 게시물 작성 API에서 동시성 제어가 필요한 부분이 있습니다. (꼭 봐주세요! 🤧)** 

예를들어, 
(해시태그 'a'는 데이터베이스에 없던 태그)

1. 유저 1이 해시태그 'a' 먼저 생성
2. 유저 2이 해시태그 'a' 생성
3. 유저 2가 게시물 먼저 작성 완료
4. 그 다음으로 유저 1이 게시물 작성 완료

1, 2번에서 해시태그 'a'를 생성하게 되는데, 3번 과정 진행되면 유저 1은 해시태그 생성 구문을 멈추고 조회로 돌아가야 합니다. 
해시태그 테이블에서 중복된 해시태그를 생성하면 안되기에, 이런 **데이터 갱신에 있어서 낙관적 락, 비관적 락과 같은 트랜잭션 격리 수준을 설정의 필요성**을 느꼈습니다! 

생각한 방법으로 우선, 저희 티쳐 포 보스의 경우 현재 단일 서버이기에 **synchronized**를 통해 동기화하여 해당 방법으로 동시성 문제를 해결할 수 있을 거 같습니다. 그러나 여러 대의 서버를 운영하는 서비스로 발전될 경우 synchronized가 적용되지 않아 중복으로 insert 하는 경우가 발생할 수 있습니다..!

다른 방법으로 데이터가 동시에 insert 될 때 충돌방지만 막으면 된다고 생각해, 비관적 락의 공유락을 적용하는 것이 좋다고 생각합니다.
우선 다른 공유락이랑 호환이 가능하고, 여러 트랜잭션에서 동시에 데이터를 읽을 수 있습니다. 그래서 비관적 락의 격리 수준 중 **Serializable Read**로 설정하는 것이 좋다고 생각했습니다..! 
해당 격리 수준으로 트랜잭션 처리 진행 중 조회/삭제/갱신을 모두 할 수 없지만 읽기 모드시 일관성을 유지해줍니다. 병목현상이 발생할 수 있지만, 게시물 작성시 동시에 같은 해시태그 생성 요청이 발생할 가능성이 낮다고 생각해 해당 수준으로 선택하는 것이 맞지 않을까.. 라고 판단했습니다.

글이 넘 길어졌는데... 위 글 내용은 어디까지나 저의 견해이고, 다른 분들은 어떤 방식을 적용하면 좋을지 궁금해서 리뷰 요청사항에 기재합니다!!