### PR TITLE
✨[FEAT] 티쳐톡 답변 작성 API

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -110,7 +110,9 @@ public enum ErrorStatus implements BaseErrorCode {
     EXAM_TAG_NOT_FOUND(NOT_FOUND, "EXAM4048", "시험 카테고리가 존재하지 않습니다."),
 
     // Board
+    INVALID_IMAGE_TIMESTAMP(BAD_REQUEST, "BOARD4001", "이미지 타임스탬프 값이 없습니다."),
     POST_NOT_FOUND(NOT_FOUND, "BOARD4041", "게시물을 찾을 수 없습니다."),
+    QUESTION_NOT_FOUND(NOT_FOUND, "BOARD4042", "질문을 찾을 수 없습니다."),
 
     // For test
     TEMP_EXCEPTION(BAD_REQUEST, "TEMP4001", "이거는 테스트");

--- a/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
@@ -1,5 +1,6 @@
 package kr.co.teacherforboss.converter;
 
+import kr.co.teacherforboss.domain.Answer;
 import kr.co.teacherforboss.domain.Category;
 import kr.co.teacherforboss.domain.Hashtag;
 import kr.co.teacherforboss.domain.Member;
@@ -139,6 +140,26 @@ public class BoardConverter {
         return BoardResponseDTO.SavePostLikeDTO.builder()
                 .like(like.getLiked().isIdentifier())
                 .updatedAt(like.getUpdatedAt())
+                .build();
+    }
+
+    public static Answer toAnswer(Question question, Member member, BoardRequestDTO.SaveAnswerDTO request) {
+        return Answer.builder()
+                .question(question)
+                .member(member)
+                .content(request.getContent())
+                .selected(BooleanType.F)
+                .likeCount(0)
+                .dislikeCount(0)
+                .imageCount(request.getImageCount())
+                .imageTimestamp(request.getImageTimestamp())
+                .build();
+    }
+
+    public static BoardResponseDTO.SaveAnswerDTO toSaveAnswerDTO(Answer answer) {
+        return BoardResponseDTO.SaveAnswerDTO.builder()
+                .answerId(answer.getId())
+                .createdAt(answer.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/kr/co/teacherforboss/domain/Answer.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Answer.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import kr.co.teacherforboss.domain.common.BaseEntity;
 import kr.co.teacherforboss.domain.enums.BooleanType;
 import lombok.AccessLevel;
@@ -16,6 +17,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Entity
 @Getter
@@ -50,4 +52,13 @@ public class Answer extends BaseEntity {
     @Column
     @ColumnDefault("0")
     private Integer dislikeCount;
+
+    @NotNull
+    @Column
+    @ColumnDefault("0")
+    private Integer imageCount;
+
+    @Column
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    protected LocalDateTime imageTimestamp;
 }

--- a/src/main/java/kr/co/teacherforboss/domain/Question.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Question.java
@@ -71,7 +71,6 @@ public class Question extends BaseEntity {
     @ColumnDefault("0")
     private Integer imageCount;
 
-    @NotNull
     @Column
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     protected LocalDateTime imageTimestamp;

--- a/src/main/java/kr/co/teacherforboss/repository/AnswerRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/AnswerRepository.java
@@ -1,0 +1,7 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+}

--- a/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
@@ -1,10 +1,12 @@
 package kr.co.teacherforboss.repository;
 
+import java.util.Optional;
+import kr.co.teacherforboss.domain.Question;
+import kr.co.teacherforboss.domain.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import kr.co.teacherforboss.domain.Question;
-
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+    Optional<Question> findByIdAndStatus(Long questionId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandService.java
@@ -1,5 +1,6 @@
 package kr.co.teacherforboss.service.boardService;
 
+import kr.co.teacherforboss.domain.Answer;
 import kr.co.teacherforboss.domain.Post;
 import kr.co.teacherforboss.domain.Question;
 import kr.co.teacherforboss.domain.PostBookmark;
@@ -11,4 +12,5 @@ public interface BoardCommandService {
     Question saveQuestion(BoardRequestDTO.SaveQuestionDTO request);
     PostBookmark savePostBookmark(Long postId);
     PostLike savePostLike(long postId);
+    Answer saveAnswer(long questionId, BoardRequestDTO.SaveAnswerDTO request);
 }

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
@@ -72,6 +72,9 @@ public class BoardCommandServiceImpl implements BoardCommandService {
 
     @Override
     public Question saveQuestion(BoardRequestDTO.SaveQuestionDTO request) {
+        if (request.getImageCount() > 0 && request.getImageTimestamp() == null)
+            throw new BoardHandler(ErrorStatus.INVALID_IMAGE_TIMESTAMP);
+
         Member member = authCommandService.getMember();
         Category category = categoryRepository.findByIdAndStatus(request.getCategoryId(), Status.ACTIVE);
         Question question = BoardConverter.toQuestion(request, member, category);

--- a/src/main/java/kr/co/teacherforboss/web/controller/BoardController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/BoardController.java
@@ -50,13 +50,13 @@ public class BoardController {
         return ApiResponse.onSuccess(BoardConverter.toSaveQuestionDTO(question));
     }
 
-    @PostMapping("/board/boss/posts/{postId}/bookmark")
+    @PostMapping("/boss/posts/{postId}/bookmark")
     public ApiResponse<BoardResponseDTO.SavePostBookmarkDTO> savePostBookmark(@PathVariable("postId") Long postId){
         PostBookmark bookmark = boardCommandService.savePostBookmark(postId);
         return ApiResponse.onSuccess(BoardConverter.toSavePostBookmarkDTO(bookmark));
     }
 
-    @PostMapping("/board/boss/posts/{postId}/likes")
+    @PostMapping("/boss/posts/{postId}/likes")
     public ApiResponse<BoardResponseDTO.SavePostLikeDTO> savePostLike(@PathVariable("postId") Long postId){
         PostLike like = boardCommandService.savePostLike(postId);
         return ApiResponse.onSuccess(BoardConverter.toSavePostLikeDTO(like));

--- a/src/main/java/kr/co/teacherforboss/web/controller/BoardController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/BoardController.java
@@ -1,5 +1,6 @@
 package kr.co.teacherforboss.web.controller;
 
+import kr.co.teacherforboss.domain.Answer;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -59,5 +60,12 @@ public class BoardController {
     public ApiResponse<BoardResponseDTO.SavePostLikeDTO> savePostLike(@PathVariable("postId") Long postId){
         PostLike like = boardCommandService.savePostLike(postId);
         return ApiResponse.onSuccess(BoardConverter.toSavePostLikeDTO(like));
+    }
+
+    @PostMapping("/teacher/questions/{questionId}/answers")
+    public ApiResponse<BoardResponseDTO.SaveAnswerDTO> saveAnswer(@PathVariable("questionId") Long questionId,
+                                                                  @RequestBody @Valid BoardRequestDTO.SaveAnswerDTO request) {
+        Answer answer = boardCommandService.saveAnswer(questionId, request);
+        return ApiResponse.onSuccess(BoardConverter.toSaveAnswerDTO(answer));
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/BoardRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/BoardRequestDTO.java
@@ -16,7 +16,7 @@ public class BoardRequestDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    public static class SavePostDTO{
+    public static class SavePostDTO {
 
         @NotNull(message = "제목은 필수 입력값입니다.")
         @Size(max = 30, message = "제목은 최대 30자 입력 가능합니다.")
@@ -37,7 +37,7 @@ public class BoardRequestDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    public static class SaveQuestionDTO{
+    public static class SaveQuestionDTO {
 
         @NotNull
         Long categoryId;
@@ -46,8 +46,8 @@ public class BoardRequestDTO {
         @Size(max = 30, message = "제목은 최대 30자 입력 가능합니다.")
         String title;
 
-        @NotNull(message = "게시물 내용은 필수 입력값입니다.")
-        @Size(max = 1000, message = "게시물 내용은 최대 1000자 입력 가능합니다.")
+        @NotNull(message = "질문 내용은 필수 입력값입니다.")
+        @Size(max = 1000, message = "질문 내용은 최대 1000자 입력 가능합니다.")
         String content;
 
         @Size(max = 5, message = "해시태그는 최대 5개까지 등록 가능합니다.")

--- a/src/main/java/kr/co/teacherforboss/web/dto/BoardRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/BoardRequestDTO.java
@@ -1,5 +1,6 @@
 package kr.co.teacherforboss.web.dto;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -53,10 +54,26 @@ public class BoardRequestDTO {
         List<String> hashtagList;
 
         @NotNull(message = "첨부 이미지 개수는 필수 입력값입니다.")
-        @Size(max = 3, message = "이미지 첨부는 최대 3개까지 가능합니다.")
+        @Max(value = 3, message = "이미지 첨부는 최대 3개까지 가능합니다.")
         Integer imageCount;
 
-        @NotNull
+        LocalDateTime imageTimestamp;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class SaveAnswerDTO {
+
+        @NotNull(message = "댓글 내용은 필수 입력값입니다.")
+        @Size(max = 3000, message = "댓글 내용은 최대 3000자 입력 가능합니다.")
+        String content;
+
+        @NotNull(message = "첨부 이미지 개수는 필수 입력값입니다.")
+        @Max(value = 3, message = "이미지 첨부는 최대 3개까지 가능합니다.")
+        Integer imageCount;
+
         LocalDateTime imageTimestamp;
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
@@ -43,6 +43,15 @@ public class BoardResponseDTO {
         LocalDateTime createdAt;
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SaveAnswerDTO {
+        Long answerId;
+        LocalDateTime createdAt;
+    }
+
     @Builder
     @Getter
     @NoArgsConstructor


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #169

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 답변 작성 API 구현
- request에 timestamp nullable하게 수정 & 서비스단에서 imageCount>0&&timestamp==null인 경우 에러 처리 (질문 작성, 답변 작성)
- Question 엔티티에 imageTimestamp @Notnull 제거
- 보스톡 게시글 좋아요 & 북마크 URI /board/board로 되어있는거 수정

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
