### PR TITLE
🐛[FIX] 회원가입 Role 선택 오타 수정

### DIFF
--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
@@ -80,7 +80,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         AgreementTerm newAgreement = AuthConverter.toAgreementTerm(request, newMember);
 
         newMember.setProfile(request.getNickname(), request.getProfileImg());
-        if (Role.of(request.getRole()).equals(Role.BOSS)) saveTeacherInfo(request);
+        if (Role.of(request.getRole()).equals(Role.TEACHER)) saveTeacherInfo(request);
 
         agreementTermRepository.save(newAgreement);
         return memberRepository.save(newMember);
@@ -253,7 +253,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         newMember.setPassword(passwordList);
 
         newMember.setProfile(request.getNickname(), request.getProfileImg());
-        if (request.getRole().equals(2)) saveTeacherInfo(request);
+        if (Role.of(request.getRole()).equals(Role.TEACHER)) saveTeacherInfo(request);
 
         return memberRepository.save(newMember);
     }


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #203 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

티쳐로 회원가입시 입력받은 role 타입에 따라 teacherInfo를 save해야하는데, 티쳐가 아닌 보스 타입일 때 해당 로직을 수행하도록 코드를 설정했었습니다. 보스에서 티쳐로 수정했습니다!

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
