### PR TITLE
❤️‍🩹 [FIX] 회원가입 400 에러 수정

### DIFF
--- a/src/main/java/kr/co/teacherforboss/repository/EmailAuthRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/EmailAuthRepository.java
@@ -1,13 +1,14 @@
 package kr.co.teacherforboss.repository;
 
 import kr.co.teacherforboss.domain.EmailAuth;
+import kr.co.teacherforboss.domain.enums.BooleanType;
 import kr.co.teacherforboss.domain.enums.Purpose;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
-    boolean existsByIdAndEmailAndPurposeAndIsChecked(Long emailAuthId, String email, Purpose purpose, String isChecked);
+    boolean existsByIdAndEmailAndPurposeAndIsChecked(Long emailAuthId, String email, Purpose purpose, BooleanType isChecked);
 
     boolean existsByIdAndPurposeAndIsChecked(Long emailAuthId, Purpose purpose, String isChecked);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/PhoneAuthRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/PhoneAuthRepository.java
@@ -1,13 +1,14 @@
 package kr.co.teacherforboss.repository;
 
 import kr.co.teacherforboss.domain.PhoneAuth;
+import kr.co.teacherforboss.domain.enums.BooleanType;
 import kr.co.teacherforboss.domain.enums.Purpose;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PhoneAuthRepository extends JpaRepository<PhoneAuth, Long> {
-    boolean existsByIdAndPhoneAndPurposeAndIsChecked(Long phoneAuthId, String phone, Purpose purpose, String isChecked);
+    boolean existsByIdAndPhoneAndPurposeAndIsChecked(Long phoneAuthId, String phone, Purpose purpose, BooleanType isChecked);
 
     boolean existsByIdAndPurposeAndIsChecked(Long phoneAuthId, Purpose purpose, String isChecked);
 }

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
@@ -11,6 +11,7 @@ import kr.co.teacherforboss.config.jwt.TokenManager;
 import kr.co.teacherforboss.converter.AuthConverter;
 import kr.co.teacherforboss.domain.BusinessAuth;
 import kr.co.teacherforboss.domain.TeacherInfo;
+import kr.co.teacherforboss.domain.enums.BooleanType;
 import kr.co.teacherforboss.domain.enums.LoginType;
 import kr.co.teacherforboss.domain.AgreementTerm;
 import kr.co.teacherforboss.domain.enums.Role;
@@ -64,13 +65,15 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     public Member joinMember(AuthRequestDTO.JoinDTO request){
         if (memberRepository.existsByEmailAndStatus(request.getEmail(), Status.ACTIVE))
             throw new AuthHandler(ErrorStatus.MEMBER_EMAIL_DUPLICATED);
-        if (!emailAuthRepository.existsByIdAndEmailAndPurposeAndIsChecked(request.getEmailAuthId(), request.getEmail(), Purpose.of(1), "T"))
+        if (!emailAuthRepository.existsByIdAndEmailAndPurposeAndIsChecked(request.getEmailAuthId(), request.getEmail(),
+                Purpose.of(1), BooleanType.T))
             throw new AuthHandler(ErrorStatus.MAIL_NOT_CHECKED);
         if (memberRepository.existsByPhoneAndStatus(request.getPhone(), Status.ACTIVE))
             throw new AuthHandler(ErrorStatus.MEMBER_PHONE_DUPLICATED);
         if (!request.getPassword().equals(request.getRePassword()))
             throw new AuthHandler(ErrorStatus.PASSWORD_NOT_CORRECT);
-        if (!phoneAuthRepository.existsByIdAndPhoneAndPurposeAndIsChecked(request.getPhoneAuthId(), request.getPhone(), Purpose.of(1), "T"))
+        if (!phoneAuthRepository.existsByIdAndPhoneAndPurposeAndIsChecked(request.getPhoneAuthId(), request.getPhone(),
+                Purpose.of(1), BooleanType.T))
             throw new AuthHandler(ErrorStatus.PHONE_NOT_CHECKED);
         if (!(request.getAgreementUsage().equals("T") && request.getAgreementInfo().equals("T") && request.getAgreementAge().equals("T")))
             throw new AuthHandler(ErrorStatus.INVALID_AGREEMENT_TERM);

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -58,7 +58,7 @@ public class AuthRequestDTO {
         @Size(max = 20, message = "분야는 최대 20자 이내로 입력 가능합니다.")
         String field;
 
-        @Max(value = 2, message = "경력은 십의 자리 수 이내로 입력 가능합니다.")
+        @Max(value = 99, message = "경력은 십의 자리 수 이내로 입력 가능합니다.")
         Integer career;
 
         @Size(max = 40, message = "한 줄 소개는 최대 40자 이내로 입력 가능합니다.")


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #207 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
dev 서버에서 회원가입시 400 에러가 발생하여, 비즈니스 로직에서 조건 검증하는 부분의 파라미터 타입과 DTO size 설정을 변경하였습니다.

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
