### PR TITLE
✨[FEAT] 이미지 저장 방식 수정

### DIFF
--- a/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
@@ -1,5 +1,6 @@
 package kr.co.teacherforboss.converter;
 
+import java.util.List;
 import kr.co.teacherforboss.domain.Answer;
 import kr.co.teacherforboss.domain.Category;
 import kr.co.teacherforboss.domain.Hashtag;
@@ -7,18 +8,12 @@ import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.Post;
 import kr.co.teacherforboss.domain.PostBookmark;
 import kr.co.teacherforboss.domain.PostHashtag;
-import kr.co.teacherforboss.domain.Question;
-import kr.co.teacherforboss.domain.QuestionHashtag;
-import kr.co.teacherforboss.domain.enums.BooleanType;
 import kr.co.teacherforboss.domain.PostLike;
-import kr.co.teacherforboss.domain.enums.BooleanType;
 import kr.co.teacherforboss.domain.Question;
 import kr.co.teacherforboss.domain.QuestionHashtag;
 import kr.co.teacherforboss.domain.enums.BooleanType;
 import kr.co.teacherforboss.web.dto.BoardRequestDTO;
 import kr.co.teacherforboss.web.dto.BoardResponseDTO;
-
-import java.util.List;
 
 public class BoardConverter {
 
@@ -52,19 +47,28 @@ public class BoardConverter {
     }
 
     public static Post toPost(BoardRequestDTO.SavePostDTO request, Member member) {
-        String imageUrlList = null;
-        if (request.getImageUrlList() != null) {
-            imageUrlList = String.join(";", request.getImageUrlList());
-        }
         return Post.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
                 .member(member)
-                .imageUrl(imageUrlList)
+                .imageUuid(extractImageUuid(request.getImageUrlList()))
+                .imageIndex(extractImageIndexs(request.getImageUrlList()))
                 .likeCount(0)
                 .bookmarkCount(0)
                 .viewCount(0)
                 .build();
+    }
+
+    public static String extractImageUuid(List<String> imageUrls) {
+        return (imageUrls == null || imageUrls.isEmpty())
+                ? null
+                : imageUrls.get(0).substring(imageUrls.get(0).lastIndexOf("/") + 1, imageUrls.get(0).indexOf("_"));
+    }
+
+    public static List<String> extractImageIndexs(List<String> imageUrls) {
+        return (imageUrls == null || imageUrls.isEmpty())
+                ? null
+                : imageUrls.stream().map(imageUrl -> imageUrl.split("_")[1]).toList();
     }
 
     public static Hashtag toHashtag(String hashtag) {
@@ -104,8 +108,8 @@ public class BoardConverter {
                 .likeCount(0)
                 .viewCount(0)
                 .bookmarkCount(0)
-                .imageCount(request.getImageCount())
-                .imageTimestamp(request.getImageTimestamp())
+                .imageUuid(extractImageUuid(request.getImageUrlList()))
+                .imageIndex(extractImageIndexs(request.getImageUrlList()))
                 .build();
     }
 
@@ -146,36 +150,10 @@ public class BoardConverter {
                 .build();
     }
 
-    public static Question toSaveQuestion(BoardRequestDTO.SaveQuestionDTO request, Member member, Category category) {
-        return Question.builder()
-                .category(category)
-                .member(member)
-                .title(request.getTitle())
-                .content(request.getContent())
-                .solved(BooleanType.F)
-                .likeCount(0)
-                .viewCount(0)
-                .bookmarkCount(0)
-                .imageCount(request.getImageCount())
-                .imageTimestamp(request.getImageTimestamp())
-                .build();
-    }
-
     public static BoardResponseDTO.EditQuestionDTO toEditQuestionDTO(Question question) {
         return BoardResponseDTO.EditQuestionDTO.builder()
                 .questionId(question.getId())
                 .createdAt(question.getCreatedAt())
-                .build();
-    }
-
-    public static Question toEditQuestion(BoardRequestDTO.EditQuestionDTO request, Member member, Category category) {
-        return Question.builder()
-                .category(category)
-                .member(member)
-                .title(request.getTitle())
-                .content(request.getContent())
-                .imageCount(request.getImageCount())
-                .imageTimestamp(request.getImageTimestamp())
                 .build();
     }
 
@@ -187,8 +165,8 @@ public class BoardConverter {
                 .selected(BooleanType.F)
                 .likeCount(0)
                 .dislikeCount(0)
-                .imageCount(request.getImageCount())
-                .imageTimestamp(request.getImageTimestamp())
+                .imageUuid(extractImageUuid(request.getImageUrlList()))
+                .imageIndex(extractImageIndexs(request.getImageUrlList()))
                 .build();
     }
 

--- a/src/main/java/kr/co/teacherforboss/converter/StringConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/StringConverter.java
@@ -1,0 +1,21 @@
+package kr.co.teacherforboss.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Arrays;
+import java.util.List;
+
+@Converter
+public class StringConverter implements AttributeConverter<List<String>, String> {
+    private static final String SPLIT_CHAR = ";";
+
+    @Override
+    public String convertToDatabaseColumn(List<String> stringList) {
+        return (stringList == null || stringList.isEmpty()) ? null : String.join(SPLIT_CHAR, stringList);
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String string) {
+        return (string == null) ? null : Arrays.asList(string.split(SPLIT_CHAR));
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/domain/Answer.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Answer.java
@@ -1,6 +1,7 @@
 package kr.co.teacherforboss.domain;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -8,7 +9,8 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDateTime;
+import java.util.List;
+import kr.co.teacherforboss.converter.StringConverter;
 import kr.co.teacherforboss.domain.common.BaseEntity;
 import kr.co.teacherforboss.domain.enums.BooleanType;
 import lombok.AccessLevel;
@@ -17,7 +19,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
-import org.springframework.format.annotation.DateTimeFormat;
 
 @Entity
 @Getter
@@ -53,12 +54,10 @@ public class Answer extends BaseEntity {
     @ColumnDefault("0")
     private Integer dislikeCount;
 
-    @NotNull
-    @Column
-    @ColumnDefault("0")
-    private Integer imageCount;
+    @Column(length = 36)
+    private String imageUuid;
 
     @Column
-    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    protected LocalDateTime imageTimestamp;
+    @Convert(converter = StringConverter.class)
+    private List<String> imageIndex;
 }

--- a/src/main/java/kr/co/teacherforboss/domain/Post.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Post.java
@@ -1,12 +1,14 @@
 package kr.co.teacherforboss.domain;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
+import kr.co.teacherforboss.converter.StringConverter;
 import kr.co.teacherforboss.domain.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -51,8 +53,12 @@ public class Post extends BaseEntity {
     @ColumnDefault("0")
     private Integer bookmarkCount;
 
+    @Column(length = 36)
+    private String imageUuid;
+
     @Column
-    private String imageUrl;
+    @Convert(converter = StringConverter.class)
+    private List<String> imageIndex;
 
     @OneToMany(mappedBy = "post")
     private List<PostHashtag> hashtagList;

--- a/src/main/java/kr/co/teacherforboss/domain/Question.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Question.java
@@ -1,6 +1,7 @@
 package kr.co.teacherforboss.domain;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -12,6 +13,7 @@ import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import kr.co.teacherforboss.converter.StringConverter;
 import kr.co.teacherforboss.domain.common.BaseEntity;
 import kr.co.teacherforboss.domain.enums.BooleanType;
 import kr.co.teacherforboss.web.dto.BoardRequestDTO;
@@ -67,24 +69,21 @@ public class Question extends BaseEntity {
     @ColumnDefault("0")
     private Integer bookmarkCount;
 
-    @NotNull
-    @Column
-    @ColumnDefault("0")
-    private Integer imageCount;
+    @Column(length = 36)
+    private String imageUuid;
 
     @Column
-    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    protected LocalDateTime imageTimestamp;
+    @Convert(converter = StringConverter.class)
+    private List<String> imageIndex;
 
     @OneToMany(mappedBy = "question")
     private List<QuestionHashtag> hashtagList;
 
-    public Question editQuestion(Category category, String title, String content, Integer imageCount, LocalDateTime imageTimestamp) {
+    public Question editQuestion(Category category, String title, String content, List<String> imageIndex) {
         this.category = category;
         this.title = title;
         this.content = content;
-        this.imageCount = imageCount;
-        this.imageTimestamp = imageTimestamp;
+        this.imageIndex = imageIndex;
         return this;
     }
 }

--- a/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
@@ -9,4 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     Optional<Question> findByIdAndStatus(Long questionId, Status status);
+    Optional<Question> findByIdAndMemberIdAndStatus(Long questionId, Long memberId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
@@ -137,7 +137,6 @@ public class BoardCommandServiceImpl implements BoardCommandService {
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.QUESTION_NOT_FOUND))
                 .editQuestion(category, request.getTitle(), request.getContent(), BoardConverter.extractImageIndexs(request.getImageUrlList()));
 
-        // TODO : 수정되고 난 후 아예 안 쓰이는 해시태그 비활성화?
         questionHashtagRepository.softDeleteAllByQuestionId(questionId);
         List<QuestionHashtag> editQuestionHashtags = new ArrayList<>();
         if (request.getHashtagList() != null) {

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
@@ -131,9 +131,8 @@ public class BoardCommandServiceImpl implements BoardCommandService {
     @Transactional
     public Question editQuestion(Long questionId, BoardRequestDTO.EditQuestionDTO request) {
         Member member = authCommandService.getMember();
-        // 여기 findByIdAndStatus 말고 findByIdAndMemberAndStatus로 해서 내가 쓴 질문인지 확인하는 로직 필요없나?
         Category category = categoryRepository.findByIdAndStatus(request.getCategoryId(), Status.ACTIVE);
-        Question editedQuestion = questionRepository.findById(questionId)
+        Question editedQuestion = questionRepository.findByIdAndMemberIdAndStatus(questionId, member.getId(), Status.ACTIVE)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.QUESTION_NOT_FOUND))
                 .editQuestion(category, request.getTitle(), request.getContent(), BoardConverter.extractImageIndexs(request.getImageUrlList()));
 

--- a/src/main/java/kr/co/teacherforboss/service/s3Service/S3QueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/s3Service/S3QueryService.java
@@ -3,5 +3,5 @@ package kr.co.teacherforboss.service.s3Service;
 import kr.co.teacherforboss.web.dto.S3ResponseDTO;
 
 public interface S3QueryService {
-	S3ResponseDTO.GetPresignedUrlDTO getPresignedUrl(String uuid, Integer lastIndex, Integer imageCount);
+	S3ResponseDTO.GetPresignedUrlDTO getPresignedUrl(String origin, String uuid, Integer lastIndex, Integer imageCount);
 }

--- a/src/main/java/kr/co/teacherforboss/service/s3Service/S3QueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/s3Service/S3QueryServiceImpl.java
@@ -32,12 +32,12 @@ public class S3QueryServiceImpl implements S3QueryService{
 	private final long URL_EXPIRATION = 1000 * 60 * 10;	// 600s
 
 	@Override
-	public S3ResponseDTO.GetPresignedUrlDTO getPresignedUrl(String uuid, Integer lastIndex, Integer imageCount) {
+	public S3ResponseDTO.GetPresignedUrlDTO getPresignedUrl(String origin, String uuid, Integer lastIndex, Integer imageCount) {
 		List<String> presignedUrlList = new ArrayList<>();
 		String imageUuid = (uuid == null) ? createUuid() : uuid;
 
 		for (int index = lastIndex + 1; index <= lastIndex + imageCount; index++) {
-			String fileName = String.format("%s_%d", imageUuid, index);
+			String fileName = String.format("%s/%s_%d", origin, imageUuid, index);
 
 			GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePresignedUrlRequest(bucket, fileName);
 			URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);

--- a/src/main/java/kr/co/teacherforboss/validation/annotation/CheckImageOrigin.java
+++ b/src/main/java/kr/co/teacherforboss/validation/annotation/CheckImageOrigin.java
@@ -1,0 +1,20 @@
+package kr.co.teacherforboss.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import kr.co.teacherforboss.validation.validator.CheckImageOriginValidator;
+
+@Documented
+@Constraint(validatedBy = CheckImageOriginValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckImageOrigin {
+    String message() default "이미지 업로드 목적이 잘못되었습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/kr/co/teacherforboss/validation/annotation/CheckImageUuid.java
+++ b/src/main/java/kr/co/teacherforboss/validation/annotation/CheckImageUuid.java
@@ -1,0 +1,20 @@
+package kr.co.teacherforboss.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import kr.co.teacherforboss.validation.validator.CheckImageUuidValidator;
+
+@Documented
+@Constraint(validatedBy = CheckImageUuidValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckImageUuid {
+    String message() default "이미지 UUID가 잘못되었습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/kr/co/teacherforboss/validation/validator/CheckImageOriginValidator.java
+++ b/src/main/java/kr/co/teacherforboss/validation/validator/CheckImageOriginValidator.java
@@ -1,0 +1,33 @@
+package kr.co.teacherforboss.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import kr.co.teacherforboss.validation.annotation.CheckImageOrigin;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CheckImageOriginValidator implements ConstraintValidator<CheckImageOrigin, String> {
+
+    private String message;
+
+    @Override
+    public void initialize(CheckImageOrigin constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.message = constraintAnnotation.message();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        boolean isValid = value != null && !value.isEmpty() &&
+                (value.equals("profiles") || value.equals("posts") || value.equals("questions") || value.equals("answers"));
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/validation/validator/CheckImageUuidValidator.java
+++ b/src/main/java/kr/co/teacherforboss/validation/validator/CheckImageUuidValidator.java
@@ -1,0 +1,38 @@
+package kr.co.teacherforboss.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.List;
+import java.util.stream.Collectors;
+import kr.co.teacherforboss.validation.annotation.CheckImageUuid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CheckImageUuidValidator implements ConstraintValidator<CheckImageUuid, List<String>> {
+
+    private String message;
+
+    @Override
+    public void initialize(CheckImageUuid constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.message = constraintAnnotation.message();
+    }
+
+    @Override
+    public boolean isValid(List<String> value, ConstraintValidatorContext context) {
+        if (value == null || value.isEmpty()) {
+            return true;
+        }
+
+        boolean isValid = value.stream().map(imageUrl -> imageUrl.split("_")[0]).collect(Collectors.toSet()).size() == 1;
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/validation/validator/CheckPurposeValidator.java
+++ b/src/main/java/kr/co/teacherforboss/validation/validator/CheckPurposeValidator.java
@@ -2,7 +2,6 @@ package kr.co.teacherforboss.validation.validator;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
 import kr.co.teacherforboss.domain.enums.Purpose;
 import kr.co.teacherforboss.validation.annotation.CheckPurpose;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/co/teacherforboss/web/controller/S3Controller.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/S3Controller.java
@@ -1,5 +1,6 @@
 package kr.co.teacherforboss.web.controller;
 
+import kr.co.teacherforboss.validation.annotation.CheckImageOrigin;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,9 +23,10 @@ public class S3Controller {
     private final S3QueryService s3QueryService;
 
     @GetMapping("/presigned-url")
-    public ApiResponse<S3ResponseDTO.GetPresignedUrlDTO> getPresignedUrl(@RequestParam(required = false) String uuid,
+    public ApiResponse<S3ResponseDTO.GetPresignedUrlDTO> getPresignedUrl(@RequestParam @CheckImageOrigin String origin,
+                                                                         @RequestParam(required = false) String uuid,
                                                                          @RequestParam(defaultValue = "0") int lastIndex,
                                                                          @RequestParam(defaultValue = "1") int imageCount) {
-        return ApiResponse.onSuccess(s3QueryService.getPresignedUrl(uuid, lastIndex, imageCount));
+        return ApiResponse.onSuccess(s3QueryService.getPresignedUrl(origin, uuid, lastIndex, imageCount));
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/BoardRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/BoardRequestDTO.java
@@ -1,16 +1,13 @@
 package kr.co.teacherforboss.web.dto;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.List;
+import kr.co.teacherforboss.validation.annotation.CheckImageUuid;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 public class BoardRequestDTO {
     @Getter
@@ -28,6 +25,7 @@ public class BoardRequestDTO {
         String content;
 
         @Size(max = 3, message = "사진은 최대 3장까지 등록 가능합니다.")
+        @CheckImageUuid
         List<String> imageUrlList;
 
         @Size(max = 5, message = "해시태그는 최대 5개까지 등록 가능합니다.")
@@ -54,12 +52,9 @@ public class BoardRequestDTO {
         @Size(max = 5, message = "해시태그는 최대 5개까지 등록 가능합니다.")
         List<String> hashtagList;
 
-        @NotNull(message = "첨부 이미지 개수는 필수 입력값입니다.")
-        @Max(value = 3, message = "이미지 첨부는 최대 3개까지 가능합니다.")
-        Integer imageCount;
-
-        @NotNull
-        LocalDateTime imageTimestamp;
+        @Size(max = 3, message = "사진은 최대 3장까지 등록 가능합니다.")
+        @CheckImageUuid
+        List<String> imageUrlList;
     }
 
     @Getter
@@ -82,11 +77,9 @@ public class BoardRequestDTO {
         @Size(max = 5, message = "해시태그는 최대 5개까지 등록 가능합니다.")
         List<String> hashtagList;
 
-        @NotNull(message = "첨부 이미지 개수는 필수 입력값입니다.")
-        @Max(value = 3, message = "이미지 첨부는 최대 3개까지 가능합니다.")
-        Integer imageCount;
-
-        LocalDateTime imageTimestamp;
+        @Size(max = 3, message = "사진은 최대 3장까지 등록 가능합니다.")
+        @CheckImageUuid
+        List<String> imageUrlList;
     }
 
     @Getter
@@ -99,10 +92,8 @@ public class BoardRequestDTO {
         @Size(max = 3000, message = "댓글 내용은 최대 3000자 입력 가능합니다.")
         String content;
 
-        @NotNull(message = "첨부 이미지 개수는 필수 입력값입니다.")
-        @Max(value = 3, message = "이미지 첨부는 최대 3개까지 가능합니다.")
-        Integer imageCount;
-
-        LocalDateTime imageTimestamp;
+        @Size(max = 3, message = "사진은 최대 3장까지 등록 가능합니다.")
+        @CheckImageUuid
+        List<String> imageUrlList;
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #215 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

이미지 저장 방식 수정했습니다. -> imageUuid & imageIndex(; delimeter)로
- Post, Question, Answer 엔티티에 imageUuid & imageIndex 칼럼으로 변경
- savePost, saveQuestion, editQuestion, saveAnswer에서 이미지 저장 로직 수정

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

- req body에 imageUrlList - null, 빈 배열, size=1, size=3 테스트 완료
<img width="841" alt="Screenshot 2024-06-12 at 5 03 19 PM" src="https://github.com/teacher-for-boss/teacher-for-boss-server/assets/79203421/cae87919-6e98-4c6b-8d45-613146e31f64">
<img width="1166" alt="Screenshot 2024-06-12 at 5 04 07 PM" src="https://github.com/teacher-for-boss/teacher-for-boss-server/assets/79203421/267b02ef-3fff-4df5-88be-a1aca1da8953">

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
