### PR TITLE
✨[FEAT] 티쳐톡 답변 수정 API

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -116,8 +116,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Board
     INVALID_IMAGE_TIMESTAMP(BAD_REQUEST, "BOARD4001", "이미지 타임스탬프 값이 없습니다."),
+
     POST_NOT_FOUND(NOT_FOUND, "BOARD4041", "게시물을 찾을 수 없습니다."),
     QUESTION_NOT_FOUND(NOT_FOUND, "BOARD4042", "질문을 찾을 수 없습니다."),
+    ANSWER_NOT_FOUND(NOT_FOUND, "BOARD4043", "답변을 찾을 수 없습니다."),
 
     // For test
     TEMP_EXCEPTION(BAD_REQUEST, "TEMP4001", "이거는 테스트");

--- a/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
@@ -170,6 +170,13 @@ public class BoardConverter {
                 .build();
     }
 
+    public static BoardResponseDTO.EditAnswerDTO toEditAnswerDTO(Answer answer) {
+        return BoardResponseDTO.EditAnswerDTO.builder()
+                .answerId(answer.getId())
+                .updatedAt(answer.getUpdatedAt())
+                .build();
+    }
+
     public static BoardResponseDTO.SaveAnswerDTO toSaveAnswerDTO(Answer answer) {
         return BoardResponseDTO.SaveAnswerDTO.builder()
                 .answerId(answer.getId())

--- a/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
@@ -153,7 +153,7 @@ public class BoardConverter {
     public static BoardResponseDTO.EditQuestionDTO toEditQuestionDTO(Question question) {
         return BoardResponseDTO.EditQuestionDTO.builder()
                 .questionId(question.getId())
-                .createdAt(question.getCreatedAt())
+                .updatedAt(question.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/kr/co/teacherforboss/domain/Answer.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Answer.java
@@ -60,4 +60,10 @@ public class Answer extends BaseEntity {
     @Column
     @Convert(converter = StringConverter.class)
     private List<String> imageIndex;
+
+    public Answer editAnswer(String content, List<String> imageIndex) {
+        this.content = content;
+        this.imageIndex = imageIndex;
+        return this;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/domain/common/BaseEntity.java
+++ b/src/main/java/kr/co/teacherforboss/domain/common/BaseEntity.java
@@ -47,8 +47,6 @@ public abstract class BaseEntity {
     protected LocalDateTime updatedAt;
 
     public boolean softDelete() {
-        if (status == Status.INACTIVE)
-            throw new GeneralException(ErrorStatus.ALREADY_DELETED);
         this.status = Status.INACTIVE;
         return true;
     }

--- a/src/main/java/kr/co/teacherforboss/domain/common/BaseEntity.java
+++ b/src/main/java/kr/co/teacherforboss/domain/common/BaseEntity.java
@@ -47,6 +47,8 @@ public abstract class BaseEntity {
     protected LocalDateTime updatedAt;
 
     public boolean softDelete() {
+        if (status == Status.INACTIVE)
+            throw new GeneralException(ErrorStatus.ALREADY_DELETED);
         this.status = Status.INACTIVE;
         return true;
     }

--- a/src/main/java/kr/co/teacherforboss/repository/AnswerRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/AnswerRepository.java
@@ -2,6 +2,7 @@ package kr.co.teacherforboss.repository;
 
 import java.util.List;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +12,5 @@ import kr.co.teacherforboss.domain.enums.Status;
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
 	List<Answer> findAllByQuestionIdAndStatus(Long questionId, Status status);
+	Optional<Answer> findByIdAndMemberIdAndStatus(Long answerId, Long memberId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
@@ -12,4 +12,5 @@ import kr.co.teacherforboss.domain.enums.Status;
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     Optional<Question> findByIdAndStatus(Long questionId, Status status);
     Optional<Question> findByIdAndMemberIdAndStatus(Long questionId, Long memberId, Status status);
+    boolean existsByIdAndStatus(Long questionId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandService.java
@@ -14,5 +14,6 @@ public interface BoardCommandService {
     PostLike savePostLike(long postId);
     Question editQuestion(Long questionId, BoardRequestDTO.EditQuestionDTO request);
     Answer saveAnswer(long questionId, BoardRequestDTO.SaveAnswerDTO request);
+    Answer editAnswer(Long questionId, Long answerId, BoardRequestDTO.EditAnswerDTO request);
     Question deleteQuestion(Long questionId);
 }

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
@@ -174,6 +174,19 @@ public class BoardCommandServiceImpl implements BoardCommandService {
 
     @Override
     @Transactional
+    public Answer editAnswer(Long questionId, Long answerId, BoardRequestDTO.EditAnswerDTO request) {
+        Member member = authCommandService.getMember();
+        if (!questionRepository.existsByIdAndStatus(questionId, Status.ACTIVE))
+            throw new BoardHandler(ErrorStatus.QUESTION_NOT_FOUND);
+
+        Answer answer = answerRepository.findByIdAndMemberIdAndStatus(answerId, member.getId(), Status.ACTIVE)
+                .orElseThrow(() -> new BoardHandler(ErrorStatus.ANSWER_NOT_FOUND));
+
+        return answer.editAnswer(request.getContent(), BoardConverter.extractImageIndexs(request.getImageUrlList()));
+    }
+
+    @Override
+    @Transactional
     public Question deleteQuestion(Long questionId) {
         Member member = authCommandService.getMember();
         Question questionToDelete = questionRepository.findByIdAndMemberIdAndStatus(questionId, member.getId(), Status.ACTIVE)

--- a/src/main/java/kr/co/teacherforboss/web/controller/BoardController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/BoardController.java
@@ -82,4 +82,12 @@ public class BoardController {
         return ApiResponse.onSuccess(BoardConverter.toDeleteQuestionDTO(question));
     }
 
+    @PatchMapping("/teacher/questions/{questionId}/answers/{answerId}")
+    public ApiResponse<BoardResponseDTO.EditAnswerDTO> editAnswer(@PathVariable("questionId") Long questionId,
+                                                                  @PathVariable("answerId") Long answerId,
+                                                                  @RequestBody @Valid BoardRequestDTO.EditAnswerDTO request) {
+        Answer answer = boardCommandService.editAnswer(questionId, answerId, request);
+        return ApiResponse.onSuccess(BoardConverter.toEditAnswerDTO(answer));
+    }
+
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/BoardRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/BoardRequestDTO.java
@@ -96,4 +96,19 @@ public class BoardRequestDTO {
         @CheckImageUuid
         List<String> imageUrlList;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class EditAnswerDTO {
+
+        @NotNull(message = "댓글 내용은 필수 입력값입니다.")
+        @Size(max = 3000, message = "댓글 내용은 최대 3000자 입력 가능합니다.")
+        String content;
+
+        @Size(max = 3, message = "사진은 최대 3장까지 등록 가능합니다.")
+        @CheckImageUuid
+        List<String> imageUrlList;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
@@ -49,7 +49,7 @@ public class BoardResponseDTO {
     @AllArgsConstructor
     public static class EditQuestionDTO {
         Long questionId;
-        LocalDateTime createdAt;
+        LocalDateTime updatedAt;
     }
 
     @Getter

--- a/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
@@ -65,6 +65,15 @@ public class BoardResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class EditAnswerDTO {
+        Long answerId;
+        LocalDateTime updatedAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class MemberInfo {
         Long memberId;
         String name;


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #217 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

티쳐톡 답변 수정 API 구현했습니다.
+
티쳐톡 질문 수정 API response에 updatedAt이어야 하는데 createdAt으로 되어있길래 이것도 수정했습니다
base entity softdelete에서 예외 던지는거 삭제했습니다 (삭제된 댓글이 존재하는 경우 게시글 삭제 시 모든 댓글을 지울 때 오류가 나서..)

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
