### PR TITLE
✨[FEAT] 보스톡 댓글 삭제 API 

### DIFF
--- a/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
@@ -513,4 +513,11 @@ public class BoardConverter {
                 .questionList(questionInfos)
                 .build();
     }
+
+    public static BoardResponseDTO.DeleteCommentDTO toDeleteCommentDTO(Comment comment) {
+        return BoardResponseDTO.DeleteCommentDTO.builder()
+                .commentId(comment.getId())
+                .deletedAt(comment.getUpdatedAt())
+                .build();
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
@@ -357,7 +357,8 @@ public class BoardConverter {
                 .build();
     }
 
-    public static BoardResponseDTO.GetCommentsDTO toGetCommentsDTO(Slice<Comment> parentComments,
+    public static BoardResponseDTO.GetCommentsDTO toGetCommentsDTO(Member member,
+                                                                   Slice<Comment> parentComments,
                                                                    List<Comment> childComments,
                                                                    List<CommentLike> commentLikes,
                                                                    List<TeacherInfo> teacherInfos) {
@@ -372,13 +373,13 @@ public class BoardConverter {
         List<BoardResponseDTO.GetCommentsDTO.CommentInfo> totalComments = new ArrayList<>();
 
         parentComments.forEach(comment -> {
-            BoardResponseDTO.GetCommentsDTO.CommentInfo commentInfo = toCommentInfo(comment, teacherInfoMap, commentLikedMap);
+            BoardResponseDTO.GetCommentsDTO.CommentInfo commentInfo = toCommentInfo(member, comment, teacherInfoMap, commentLikedMap);
             parentCommentMap.put(comment.getId(), commentInfo);
             totalComments.add(commentInfo);
         });
 
         childComments.forEach(comment -> {
-            BoardResponseDTO.GetCommentsDTO.CommentInfo commentInfo = toCommentInfo(comment, teacherInfoMap, commentLikedMap);
+            BoardResponseDTO.GetCommentsDTO.CommentInfo commentInfo = toCommentInfo(member, comment, teacherInfoMap, commentLikedMap);
             childCommentMap.put(comment.getId(), commentInfo);
 
             BoardResponseDTO.GetCommentsDTO.CommentInfo parentCommentInfo = parentCommentMap.get(comment.getParent().getId());
@@ -393,14 +394,15 @@ public class BoardConverter {
                 .build();
     }
 
-    public static BoardResponseDTO.GetCommentsDTO.CommentInfo toCommentInfo (Comment comment,
+    public static BoardResponseDTO.GetCommentsDTO.CommentInfo toCommentInfo (Member member,
+                                                                             Comment comment,
                                                                              Map<Long, TeacherInfo> teacherInfoMap,
                                                                              Map<Long, BooleanType> commentLikedMap) {
-
         TeacherInfo teacherInfo = teacherInfoMap.get(comment.getMember().getId());
         BoardResponseDTO.MemberInfo memberInfo = BoardConverter.toMemberInfo(comment.getMember(), teacherInfo);
 
         return BoardResponseDTO.GetCommentsDTO.CommentInfo.builder()
+                .isMine(comment.getMember().getId() == member.getId())
                 .commentId(comment.getId())
                 .content(comment.getContent())
                 .likeCount(comment.getLikeCount())

--- a/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
@@ -362,8 +362,7 @@ public class BoardConverter {
                                                                    Slice<Comment> parentComments,
                                                                    List<Comment> childComments,
                                                                    List<CommentLike> commentLikes,
-                                                                   List<TeacherInfo> teacherInfos,
-                                                                   Member member) {
+                                                                   List<TeacherInfo> teacherInfos) {
         HashMap<Long, BooleanType> commentLikedMap = new HashMap<>();
         commentLikes.forEach(commentLike -> commentLikedMap.put(commentLike.getComment().getId(), commentLike.getLiked()));
 
@@ -400,8 +399,6 @@ public class BoardConverter {
                                                                              Comment comment,
                                                                              Map<Long, TeacherInfo> teacherInfoMap,
                                                                              Map<Long, BooleanType> commentLikedMap) {
-                                                                             Map<Long, BooleanType> commentLikedMap,
-                                                                             Member member) {
         TeacherInfo teacherInfo = teacherInfoMap.get(comment.getMember().getId());
         BoardResponseDTO.MemberInfo memberInfo = BoardConverter.toMemberInfo(comment.getMember(), teacherInfo);
 

--- a/src/main/java/kr/co/teacherforboss/repository/CommentRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/CommentRepository.java
@@ -49,4 +49,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     """, nativeQuery = true)
     List<Comment> findAllByPostIdAndParentIdInAndStatus(@Param("postId") Long postId,
                                                         @Param("parentIds") List<Long> parentIds);
+
+    Optional<Comment> findByIdAndPostIdAndMemberIdAndStatus(Long commentId, Long postId, Long memberId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandService.java
@@ -30,4 +30,5 @@ public interface BoardCommandService {
     Answer selectAnswer(Long questionId, Long answerId);
     CommentLike toggleCommentLike(Long postId, Long commentId, boolean isLike);
     Comment saveComment(Long postId, BoardRequestDTO.SaveCommentDTO request);
+    Comment deleteComment(Long postId, Long commentId);
 }

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
@@ -354,4 +354,15 @@ public class BoardCommandServiceImpl implements BoardCommandService {
         question.selectAnswer(answer);
         return answer;
     }
+
+    @Override
+    @Transactional
+    public Comment deleteComment(Long postId, Long commentId) {
+        Member member = authCommandService.getMember();
+        Comment commentToDelete = commentRepository.findByIdAndPostIdAndMemberIdAndStatus(commentId, postId, member.getId(), Status.ACTIVE)
+                .orElseThrow(() -> new BoardHandler(ErrorStatus.COMMENT_NOT_FOUND));
+
+        commentToDelete.softDelete();
+        return commentToDelete;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardQueryServiceImpl.java
@@ -171,6 +171,8 @@ public class BoardQueryServiceImpl implements BoardQueryService {
             throw new BoardHandler(ErrorStatus.POST_NOT_FOUND);
         }
 
+        Member member = authCommandService.getMember();
+
         PageRequest pageRequest = PageRequest.of(0, size);
         Slice<Comment> parentComments;
 
@@ -190,7 +192,7 @@ public class BoardQueryServiceImpl implements BoardQueryService {
         List<CommentLike> commentLikes = commentLikeRepository.findAllByCommentIdInAndStatus(allCommentIds, Status.ACTIVE);
         List<TeacherInfo> teacherInfos = teacherInfoRepository.findAllByMemberIdInAndStatus(memberIds, Status.ACTIVE);
 
-        return BoardConverter.toGetCommentsDTO(parentComments, childComments, commentLikes, teacherInfos);
+        return BoardConverter.toGetCommentsDTO(member, parentComments, childComments, commentLikes, teacherInfos);
     }
 
 

--- a/src/main/java/kr/co/teacherforboss/web/controller/BoardController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/BoardController.java
@@ -212,4 +212,11 @@ public class BoardController {
                                                               @RequestParam(defaultValue = "10") int size){
         return ApiResponse.onSuccess(boardQueryService.searchPosts(keyword, lastPostId, size));
     }
+
+    @DeleteMapping("/boss/posts/{postId}/comments/{commentId}")
+    public ApiResponse<BoardResponseDTO.DeleteCommentDTO> deleteComment(@PathVariable("postId") Long postId,
+                                                                        @PathVariable("commentId") Long commentId) {
+        Comment comment = boardCommandService.deleteComment(postId, commentId);
+        return ApiResponse.onSuccess(BoardConverter.toDeleteCommentDTO(comment));
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
@@ -316,4 +316,13 @@ public class BoardResponseDTO {
             LocalDateTime createdAt;
         }
 	}
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DeleteCommentDTO {
+        Long commentId;
+        LocalDateTime deletedAt;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
@@ -118,6 +118,7 @@ public class BoardResponseDTO {
         @Getter
         @AllArgsConstructor
         public static class CommentInfo {
+            boolean isMine;
             Long commentId;
             String content;
             int likeCount;

--- a/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
@@ -128,7 +128,6 @@ public class BoardResponseDTO {
             boolean disliked;
             LocalDateTime createdAt;
             MemberInfo memberInfo;
-            Boolean isMine;
             List<CommentInfo> children;
         }
     }


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #246 

## 📝 작업 내용

- 보스톡 댓글 삭제 기능을 구현합니다.
<img width="491" alt="image" src="https://github.com/teacher-for-boss/teacher-for-boss-server/assets/113760409/bbbe2dec-e3d9-4812-ba46-4fb07dee6099">

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
