### PR TITLE
✨[FEAT] 티쳐 프로필 상세 조회

### DIFF
--- a/src/main/java/kr/co/teacherforboss/converter/MemberConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/MemberConverter.java
@@ -1,7 +1,10 @@
 package kr.co.teacherforboss.converter;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
 import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.MemberSurvey;
 import kr.co.teacherforboss.domain.TeacherInfo;
@@ -50,6 +53,21 @@ public class MemberConverter {
                     return new HomeResponseDTO.GetHotTeachersDTO.HotTeacherInfo(member.getId(), member.getNickname(), member.getProfileImg(),
                             teacherInfo.getField(), teacherInfo.getCareer(), teacherInfo.getKeywords());
                 }).toList())
+                .build();
+    }
+
+    public static MemberResponseDTO.GetTeacherProfileDTO toGetTeacherProfileDTO(Member member, TeacherInfo teacherInfo, boolean isMine) {
+        return MemberResponseDTO.GetTeacherProfileDTO.builder()
+                .nickname(member.getNickname())
+                .profileImg(member.getProfileImg())
+                .introduction(teacherInfo.getIntroduction())
+                .phone(member.getPhone())
+                .email(member.getEmail())
+                .field(teacherInfo.getField())
+                .career(teacherInfo.getCareer())
+                .keywords(Arrays.stream(teacherInfo.getKeywords().split(";")).collect(Collectors.toList()))
+                .level(teacherInfo.getLevel().getLevel())
+                .isMine(isMine)
                 .build();
     }
 }

--- a/src/main/java/kr/co/teacherforboss/service/memberService/MemberQueryService.java
+++ b/src/main/java/kr/co/teacherforboss/service/memberService/MemberQueryService.java
@@ -1,8 +1,10 @@
 package kr.co.teacherforboss.service.memberService;
 
 import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.web.dto.MemberResponseDTO;
 
 
 public interface MemberQueryService {
     Member getMemberProfile();
+    MemberResponseDTO.GetTeacherProfileDTO getTeacherProfile();
 }

--- a/src/main/java/kr/co/teacherforboss/service/memberService/MemberQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/memberService/MemberQueryServiceImpl.java
@@ -2,10 +2,14 @@ package kr.co.teacherforboss.service.memberService;
 
 import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
 import kr.co.teacherforboss.apiPayload.exception.handler.MemberHandler;
+import kr.co.teacherforboss.converter.MemberConverter;
 import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.TeacherInfo;
 import kr.co.teacherforboss.domain.enums.Status;
 import kr.co.teacherforboss.repository.MemberRepository;
+import kr.co.teacherforboss.repository.TeacherInfoRepository;
 import kr.co.teacherforboss.service.authService.AuthCommandService;
+import kr.co.teacherforboss.web.dto.MemberResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +20,7 @@ public class MemberQueryServiceImpl implements MemberQueryService{
 
     private final MemberRepository memberRepository;
     private final AuthCommandService authCommandService;
+    private final TeacherInfoRepository teacherInfoRepository;
 
     @Override
     @Transactional
@@ -23,5 +28,17 @@ public class MemberQueryServiceImpl implements MemberQueryService{
         Member member = authCommandService.getMember();
         return memberRepository.findByIdAndStatus(member.getId(), Status.ACTIVE)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    @Override
+    @Transactional
+    public MemberResponseDTO.GetTeacherProfileDTO getTeacherProfile() {
+        Member member = authCommandService.getMember();
+        TeacherInfo teacherInfo = teacherInfoRepository.findByMemberIdAndStatus(member.getId(), Status.ACTIVE)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.TEACHER_INFO_NOT_FOUND));
+
+        boolean isMine = member.equals(teacherInfo.getMember());
+
+        return MemberConverter.toGetTeacherProfileDTO(member, teacherInfo, isMine);
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/controller/MemberController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/MemberController.java
@@ -17,11 +17,8 @@ import kr.co.teacherforboss.service.memberService.MemberCommandService;
 import kr.co.teacherforboss.web.dto.MemberRequestDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @Validated
@@ -36,6 +33,11 @@ public class MemberController {
     public ApiResponse<MemberResponseDTO.GetMemberProfileDTO> getMemberProfile() {
         Member member = memberQueryService.getMemberProfile();
         return ApiResponse.onSuccess(MemberConverter.toGetMemberProfileDTO(member));
+    }
+
+    @GetMapping("/profiles/detail")
+    public ApiResponse<MemberResponseDTO.GetTeacherProfileDTO> getMemberProfileDetail() {
+        return ApiResponse.onSuccess(memberQueryService.getTeacherProfile());
     }
 
     @PostMapping("/survey")

--- a/src/main/java/kr/co/teacherforboss/web/dto/MemberResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/MemberResponseDTO.java
@@ -1,6 +1,8 @@
 package kr.co.teacherforboss.web.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -43,5 +45,22 @@ public class MemberResponseDTO {
     public static class EditMemberProfileDTO {
         String nickname;
         String profileImg;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetTeacherProfileDTO {
+        String nickname;
+        String profileImg;
+        String introduction;
+        String phone;
+        String email;
+        String field;
+        Integer career;
+        List<String> keywords;
+        String level;
+        boolean isMine;
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #256 

## 📝 작업 내용

티처 프로필 상세 조회 기능 구현했습니다.
<img width="460" alt="image" src="https://github.com/user-attachments/assets/edcf7f53-4ce0-4969-8562-5508b1ff3934">


## 📝 예외 처리

티처가 아닌 경우는 teacherInfo 값을 불러올 때 repository에 존재하는 findByMemberIdAndStatus가 Optional이라, 티처 정보가 존재하지 않음으로 예외처리 했습니다. (findByMemberIdAndStatus를 재사용하기 위해 이러한 방식으로 구현했는데, 그냥 member Role값을 확인해서 예외처리를 명시해주는게 더 좋을까요?)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
