### PR TITLE
✨[FEAT] 티포 환전 신청 API

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -132,9 +132,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_HOT_TEACHER_DATA(NOT_FOUND, "HOME4041", "인기 티쳐 정보를 찾을 수 없습니다."),
 
     // Payment
-    TEACHER_POINT_LIMIT_UNDER(BAD_REQUEST, "PAYMENT4001", "보유한 티포 포인트가 550TP 미만입니다."),
-    TEACHER_POINT_LIMIT_OVER(BAD_REQUEST, "PAYMENT4002", "보유한 티포 포인트보다 초과한 값을 입력했습니다."),
-    TEACHER_POINT_INVALID_UNIT_DIVISION(BAD_REQUEST, "PAYMENT4003", "티포 환전은 100TP 단위로 가능합니다."),
+    TEACHER_POINT_LIMIT_OVER(BAD_REQUEST, "PAYMENT4001", "보유한 티포 포인트보다 초과한 값을 입력했습니다."),
 
     // For test
     TEMP_EXCEPTION(BAD_REQUEST, "TEMP4001", "이거는 테스트");

--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -131,6 +131,11 @@ public enum ErrorStatus implements BaseErrorCode {
     // Home
     INVALID_HOT_TEACHER_DATA(NOT_FOUND, "HOME4041", "인기 티쳐 정보를 찾을 수 없습니다."),
 
+    // Payment
+    TEACHER_POINT_LIMIT_UNDER(BAD_REQUEST, "PAYMENT4001", "보유한 티포 포인트가 550TP 미만입니다."),
+    TEACHER_POINT_LIMIT_OVER(BAD_REQUEST, "PAYMENT4002", "보유한 티포 포인트보다 초과한 값을 입력했습니다."),
+    TEACHER_POINT_INVALID_UNIT_DIVISION(BAD_REQUEST, "PAYMENT4003", "티포 환전은 100TP 단위로 가능합니다."),
+
     // For test
     TEMP_EXCEPTION(BAD_REQUEST, "TEMP4001", "이거는 테스트");
 

--- a/src/main/java/kr/co/teacherforboss/apiPayload/exception/handler/PaymentHandler.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/exception/handler/PaymentHandler.java
@@ -1,0 +1,11 @@
+package kr.co.teacherforboss.apiPayload.exception.handler;
+
+import kr.co.teacherforboss.apiPayload.code.BaseErrorCode;
+import kr.co.teacherforboss.apiPayload.exception.GeneralException;
+
+public class PaymentHandler extends GeneralException {
+
+    public PaymentHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/converter/PaymentConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/PaymentConverter.java
@@ -1,7 +1,9 @@
 package kr.co.teacherforboss.converter;
 
 
+import kr.co.teacherforboss.domain.Exchange;
 import kr.co.teacherforboss.domain.TeacherInfo;
+import kr.co.teacherforboss.domain.enums.BooleanType;
 import kr.co.teacherforboss.util.AES256Util;
 import kr.co.teacherforboss.web.dto.PaymentResponseDTO;
 
@@ -17,6 +19,20 @@ public class PaymentConverter {
     public static PaymentResponseDTO.EditTeacherAccountDTO toEditTeacherAccountDTO(TeacherInfo teacherInfo) {
         return PaymentResponseDTO.EditTeacherAccountDTO.builder()
                 .updatedAt(teacherInfo.getUpdatedAt())
+                .build();
+    }
+
+    public static Exchange toExchange(int points) {
+        return Exchange.builder()
+                .points(points)
+                .isComplete(BooleanType.F)
+                .build();
+    }
+
+    public static PaymentResponseDTO.ExchangeTeacherPointDTO toExchangeTeacherPoint(Exchange exchange) {
+        return PaymentResponseDTO.ExchangeTeacherPointDTO.builder()
+                .exchangeId(exchange.getId())
+                .createdAt(exchange.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/kr/co/teacherforboss/converter/PaymentConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/PaymentConverter.java
@@ -33,8 +33,8 @@ public class PaymentConverter {
                 .build();
     }
 
-    public static PaymentResponseDTO.ExchangeTeacherPointDTO toExchangeTeacherPoints(Exchange exchange) {
-        return PaymentResponseDTO.ExchangeTeacherPointDTO.builder()
+    public static PaymentResponseDTO.ExchangeTeacherPointsDTO toExchangeTeacherPoints(Exchange exchange) {
+        return PaymentResponseDTO.ExchangeTeacherPointsDTO.builder()
                 .exchangeId(exchange.getId())
                 .createdAt(exchange.getCreatedAt())
                 .build();

--- a/src/main/java/kr/co/teacherforboss/converter/PaymentConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/PaymentConverter.java
@@ -29,7 +29,7 @@ public class PaymentConverter {
                 .build();
     }
 
-    public static PaymentResponseDTO.ExchangeTeacherPointDTO toExchangeTeacherPoint(Exchange exchange) {
+    public static PaymentResponseDTO.ExchangeTeacherPointDTO toExchangeTeacherPoints(Exchange exchange) {
         return PaymentResponseDTO.ExchangeTeacherPointDTO.builder()
                 .exchangeId(exchange.getId())
                 .createdAt(exchange.getCreatedAt())

--- a/src/main/java/kr/co/teacherforboss/converter/PaymentConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/PaymentConverter.java
@@ -2,8 +2,10 @@ package kr.co.teacherforboss.converter;
 
 
 import kr.co.teacherforboss.domain.Exchange;
+import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.TeacherInfo;
 import kr.co.teacherforboss.domain.enums.BooleanType;
+import kr.co.teacherforboss.domain.enums.ExchangeType;
 import kr.co.teacherforboss.util.AES256Util;
 import kr.co.teacherforboss.web.dto.PaymentResponseDTO;
 
@@ -22,8 +24,10 @@ public class PaymentConverter {
                 .build();
     }
 
-    public static Exchange toExchange(int points) {
+    public static Exchange toExchange(Member member, int points) {
         return Exchange.builder()
+                .member(member)
+                .exchangeType(ExchangeType.EX)
                 .points(points)
                 .isComplete(BooleanType.F)
                 .build();

--- a/src/main/java/kr/co/teacherforboss/domain/Exchange.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Exchange.java
@@ -4,9 +4,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import kr.co.teacherforboss.domain.common.BaseEntity;
 import kr.co.teacherforboss.domain.enums.BooleanType;
+import kr.co.teacherforboss.domain.enums.ExchangeType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,6 +25,15 @@ import org.hibernate.annotations.ColumnDefault;
 @AllArgsConstructor
 public class Exchange extends BaseEntity {
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId")
+    private Member member;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)")
+    private ExchangeType exchangeType;
+
     @NotNull
     @Column
     @ColumnDefault("0")
@@ -30,4 +43,5 @@ public class Exchange extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @ColumnDefault("'F'")
     private BooleanType isComplete;
+
 }

--- a/src/main/java/kr/co/teacherforboss/domain/Exchange.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Exchange.java
@@ -1,0 +1,33 @@
+package kr.co.teacherforboss.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotNull;
+import kr.co.teacherforboss.domain.common.BaseEntity;
+import kr.co.teacherforboss.domain.enums.BooleanType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Exchange extends BaseEntity {
+
+    @NotNull
+    @Column
+    @ColumnDefault("0")
+    private Integer points;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'F'")
+    private BooleanType isComplete;
+}

--- a/src/main/java/kr/co/teacherforboss/domain/TeacherSelectInfo.java
+++ b/src/main/java/kr/co/teacherforboss/domain/TeacherSelectInfo.java
@@ -28,7 +28,7 @@ public class TeacherSelectInfo extends BaseEntity {
     @NotNull
     @Column
     @Builder.Default
-    private Integer point = 0;
+    private Integer points = 0;
 
     @NotNull
     @Column
@@ -39,8 +39,9 @@ public class TeacherSelectInfo extends BaseEntity {
         this.selectCount++;
     }
 
-    public void addPoint(int point) {
-        this.point += point;
+    public void addPoints(int points) {
+        this.points += points;
     }
 
+    public void decreasePoints(int points) { this.points -= points; }
 }

--- a/src/main/java/kr/co/teacherforboss/domain/TeacherSelectInfo.java
+++ b/src/main/java/kr/co/teacherforboss/domain/TeacherSelectInfo.java
@@ -43,5 +43,7 @@ public class TeacherSelectInfo extends BaseEntity {
         this.points += points;
     }
 
-    public void decreasePoints(int points) { this.points -= points; }
+    public void decreasePoints(int points) {
+        this.points -= points;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/domain/enums/ExchangeType.java
+++ b/src/main/java/kr/co/teacherforboss/domain/enums/ExchangeType.java
@@ -1,0 +1,13 @@
+package kr.co.teacherforboss.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExchangeType {
+    EX("exchange"),
+    RF("refund");
+
+    private final String identifier;
+}

--- a/src/main/java/kr/co/teacherforboss/domain/vo/mailVO/ExchangeMail.java
+++ b/src/main/java/kr/co/teacherforboss/domain/vo/mailVO/ExchangeMail.java
@@ -33,13 +33,11 @@ public class ExchangeMail extends Mail {
     }
 
     private String getCharge(int appliedTP) {
-        int exchangedMoney = appliedTP * 100;
-        int finalMoney = (int) (exchangedMoney * 0.9);
-        return String.valueOf(exchangedMoney - finalMoney);
+        return String.valueOf(appliedTP * 100 * 0.1);
     }
 
     private String getFinalMoney(int appliedTP) {
-         return String.valueOf(appliedTP * 100);
+         return String.valueOf(appliedTP * 100 * 0.9);
     }
 
     private String getAccountNumber(TeacherInfo teacherInfo) {

--- a/src/main/java/kr/co/teacherforboss/domain/vo/mailVO/ExchangeMail.java
+++ b/src/main/java/kr/co/teacherforboss/domain/vo/mailVO/ExchangeMail.java
@@ -1,0 +1,56 @@
+package kr.co.teacherforboss.domain.vo.mailVO;
+
+import kr.co.teacherforboss.domain.TeacherInfo;
+import kr.co.teacherforboss.util.AES256Util;
+
+public class ExchangeMail extends Mail {
+    public ExchangeMail(int ownedTP, int appliedTP, TeacherInfo teacherInfo) {
+        super("exchange", "[티쳐 포 보스] 환전 신청");
+        super.values.put("email", getEmail(teacherInfo));
+        super.values.put("ownedTP", getOwnedTP(ownedTP));
+        super.values.put("appliedTP", getAppliedTP(appliedTP));
+        super.values.put("remainingTP", getRemainingTP(ownedTP, appliedTP));
+        super.values.put("charge", getCharge(appliedTP));
+        super.values.put("finalMoney", getFinalMoney(appliedTP));
+        super.values.put("accountNumber", getAccountNumber(teacherInfo));
+        super.values.put("bank", getBank(teacherInfo));
+        super.values.put("accountHolder", getAccountHolder(teacherInfo));
+    }
+
+    private String getEmail(TeacherInfo teacherInfo) {
+        return teacherInfo.getMember().getEmail();
+    }
+    private String getOwnedTP(int ownedTP) {
+        return String.valueOf(ownedTP);
+    }
+
+    private String getAppliedTP(int appliedTP) {
+        return String.valueOf(appliedTP);
+    }
+
+    private String getRemainingTP(int ownedTP, int appliedTP) {
+        return String.valueOf(ownedTP - appliedTP);
+    }
+
+    private String getCharge(int appliedTP) {
+        int exchangedMoney = appliedTP * 100;
+        int finalMoney = (int) (exchangedMoney * 0.9);
+        return String.valueOf(exchangedMoney - finalMoney);
+    }
+
+    private String getFinalMoney(int appliedTP) {
+         return String.valueOf(appliedTP * 100);
+    }
+
+    private String getAccountNumber(TeacherInfo teacherInfo) {
+        return AES256Util.decrypt(teacherInfo.getAccountNumber());
+    }
+
+    private String getBank(TeacherInfo teacherInfo) {
+        return teacherInfo.getBank();
+    }
+
+    private String getAccountHolder(TeacherInfo teacherInfo) {
+        return teacherInfo.getAccountHolder();
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/repository/ExchangeRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/ExchangeRepository.java
@@ -1,0 +1,9 @@
+package kr.co.teacherforboss.repository;
+
+import kr.co.teacherforboss.domain.Exchange;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ExchangeRepository extends JpaRepository<Exchange, Long> {
+}

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
@@ -366,7 +366,7 @@ public class BoardCommandServiceImpl implements BoardCommandService {
 
         question.selectAnswer(answer);
         teacherSelectInfo.increaseSelectCount();
-        teacherSelectInfo.addPoint(Question.POINT);
+        teacherSelectInfo.addPoints(Question.POINT);
 
         return answer;
     }

--- a/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandService.java
@@ -1,8 +1,10 @@
 package kr.co.teacherforboss.service.paymentService;
 
+import kr.co.teacherforboss.domain.Exchange;
 import kr.co.teacherforboss.domain.TeacherInfo;
 import kr.co.teacherforboss.web.dto.PaymentRequestDTO;
 
 public interface PaymentCommandService {
     TeacherInfo editTeacherAccount(PaymentRequestDTO.EditTeacherAccountDTO request);
+    Exchange exchangeTeacherPoint(PaymentRequestDTO.ExchangeTeacherPointDTO request);
 }

--- a/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandService.java
@@ -6,5 +6,5 @@ import kr.co.teacherforboss.web.dto.PaymentRequestDTO;
 
 public interface PaymentCommandService {
     TeacherInfo editTeacherAccount(PaymentRequestDTO.EditTeacherAccountDTO request);
-    Exchange exchangeTeacherPoint(PaymentRequestDTO.ExchangeTeacherPointDTO request);
+    Exchange exchangeTeacherPoints(PaymentRequestDTO.ExchangeTeacherPointsDTO request);
 }

--- a/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
@@ -30,6 +30,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     private final TeacherInfoRepository teacherInfoRepository;
     private final TeacherSelectInfoRepository teacherSelectInfoRepository;
     private final ExchangeRepository exchangeRepository;
+    private final int EXCHANGE_UNDER_LIMIT = 550;
 
     @Override
     @Transactional
@@ -56,7 +57,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
         TeacherSelectInfo teacherSelectInfo = teacherSelectInfoRepository.findByMemberIdAndStatus(member.getId(), Status.ACTIVE)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.TEACHER_SELECT_INFO_NOT_FOUND));
 
-        if (teacherSelectInfo.getPoints() < 550) throw new PaymentHandler(ErrorStatus.TEACHER_POINT_LIMIT_UNDER);
+        if (teacherSelectInfo.getPoints() < EXCHANGE_UNDER_LIMIT) throw new PaymentHandler(ErrorStatus.TEACHER_POINT_LIMIT_UNDER);
         if (request.getPoints() > teacherSelectInfo.getPoints()) throw new PaymentHandler(ErrorStatus.TEACHER_POINT_LIMIT_OVER);
         if (request.getPoints() % 100 != 0) throw new PaymentHandler(ErrorStatus.TEACHER_POINT_INVALID_UNIT_DIVISION);
 

--- a/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
@@ -2,12 +2,20 @@ package kr.co.teacherforboss.service.paymentService;
 
 import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
 import kr.co.teacherforboss.apiPayload.exception.handler.MemberHandler;
+import kr.co.teacherforboss.apiPayload.exception.handler.PaymentHandler;
+import kr.co.teacherforboss.converter.PaymentConverter;
+import kr.co.teacherforboss.domain.Exchange;
 import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.TeacherInfo;
+import kr.co.teacherforboss.domain.TeacherSelectInfo;
 import kr.co.teacherforboss.domain.enums.Role;
 import kr.co.teacherforboss.domain.enums.Status;
+import kr.co.teacherforboss.domain.vo.mailVO.ExchangeMail;
+import kr.co.teacherforboss.repository.ExchangeRepository;
 import kr.co.teacherforboss.repository.TeacherInfoRepository;
+import kr.co.teacherforboss.repository.TeacherSelectInfoRepository;
 import kr.co.teacherforboss.service.authService.AuthCommandService;
+import kr.co.teacherforboss.service.mailService.MailCommandService;
 import kr.co.teacherforboss.web.dto.PaymentRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,7 +26,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class PaymentCommandServiceImpl implements PaymentCommandService {
 
     private final AuthCommandService authCommandService;
+    private final MailCommandService mailCommandService;
     private final TeacherInfoRepository teacherInfoRepository;
+    private final TeacherSelectInfoRepository teacherSelectInfoRepository;
+    private final ExchangeRepository exchangeRepository;
 
     @Override
     @Transactional
@@ -33,5 +44,28 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
 
         teacherInfo.editTeacherAccount(request.getBank(), request.getAccountNumber(), request.getAccountHolder());
         return teacherInfoRepository.save(teacherInfo);
+    }
+
+    @Override
+    @Transactional
+    public Exchange exchangeTeacherPoint(PaymentRequestDTO.ExchangeTeacherPointDTO request){
+        Member member = authCommandService.getMember();
+        if (member.getRole() != Role.TEACHER) throw new MemberHandler(ErrorStatus.MEMBER_ROLE_NOT_TEACHER);
+        TeacherInfo teacherInfo = teacherInfoRepository.findByMemberIdAndStatus(member.getId(), Status.ACTIVE)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.TEACHER_INFO_NOT_FOUND));
+        TeacherSelectInfo teacherSelectInfo = teacherSelectInfoRepository.findByMemberIdAndStatus(member.getId(), Status.ACTIVE)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.TEACHER_SELECT_INFO_NOT_FOUND));
+
+        if (teacherSelectInfo.getPoints() < 550) throw new PaymentHandler(ErrorStatus.TEACHER_POINT_LIMIT_UNDER);
+        if (request.getPoints() > teacherSelectInfo.getPoints()) throw new PaymentHandler(ErrorStatus.TEACHER_POINT_LIMIT_OVER);
+        if (request.getPoints() % 100 != 0) throw new PaymentHandler(ErrorStatus.TEACHER_POINT_INVALID_UNIT_DIVISION);
+
+        ExchangeMail exchangeMail = new ExchangeMail(teacherSelectInfo.getPoints(), request.getPoints(), teacherInfo);
+        mailCommandService.sendMail(member.getEmail(), exchangeMail);
+
+        Exchange exchange = PaymentConverter.toExchange(request.getPoints());
+        teacherSelectInfo.decreasePoints(request.getPoints());
+        teacherSelectInfoRepository.save(teacherSelectInfo);
+        return exchangeRepository.save(exchange);
     }
 }

--- a/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
@@ -30,7 +30,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     private final TeacherInfoRepository teacherInfoRepository;
     private final TeacherSelectInfoRepository teacherSelectInfoRepository;
     private final ExchangeRepository exchangeRepository;
-    private final int EXCHANGE_UNDER_LIMIT = 550;
+    private static final int EXCHANGE_UNDER_LIMIT = 550;
 
     @Override
     @Transactional

--- a/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
@@ -30,7 +30,6 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     private final TeacherInfoRepository teacherInfoRepository;
     private final TeacherSelectInfoRepository teacherSelectInfoRepository;
     private final ExchangeRepository exchangeRepository;
-    private static final int EXCHANGE_UNDER_LIMIT = 550;
 
     @Override
     @Transactional

--- a/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
@@ -64,9 +64,8 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
         ExchangeMail exchangeMail = new ExchangeMail(teacherSelectInfo.getPoints(), request.getPoints(), teacherInfo);
         mailCommandService.sendMail(member.getEmail(), exchangeMail);
 
-        Exchange exchange = PaymentConverter.toExchange(request.getPoints());
+        Exchange exchange = PaymentConverter.toExchange(member, request.getPoints());
         teacherSelectInfo.decreasePoints(request.getPoints());
-        teacherSelectInfoRepository.save(teacherSelectInfo);
         return exchangeRepository.save(exchange);
     }
 }

--- a/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
@@ -61,6 +61,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
         if (request.getPoints() > teacherSelectInfo.getPoints()) throw new PaymentHandler(ErrorStatus.TEACHER_POINT_LIMIT_OVER);
         if (request.getPoints() % 100 != 0) throw new PaymentHandler(ErrorStatus.TEACHER_POINT_INVALID_UNIT_DIVISION);
 
+        // TODO: 메일 보내는거 비동기로 처리
         ExchangeMail exchangeMail = new ExchangeMail(teacherSelectInfo.getPoints(), request.getPoints(), teacherInfo);
         mailCommandService.sendMail(member.getEmail(), exchangeMail);
 

--- a/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
@@ -55,9 +55,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
         TeacherSelectInfo teacherSelectInfo = teacherSelectInfoRepository.findByMemberIdAndStatus(member.getId(), Status.ACTIVE)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.TEACHER_SELECT_INFO_NOT_FOUND));
 
-        if (teacherSelectInfo.getPoints() < EXCHANGE_UNDER_LIMIT) throw new PaymentHandler(ErrorStatus.TEACHER_POINT_LIMIT_UNDER);
         if (request.getPoints() > teacherSelectInfo.getPoints()) throw new PaymentHandler(ErrorStatus.TEACHER_POINT_LIMIT_OVER);
-        if (request.getPoints() % 100 != 0) throw new PaymentHandler(ErrorStatus.TEACHER_POINT_INVALID_UNIT_DIVISION);
 
         // TODO: 메일 보내는거 비동기로 처리
         ExchangeMail exchangeMail = new ExchangeMail(teacherSelectInfo.getPoints(), request.getPoints(), teacherInfo);

--- a/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
@@ -47,7 +47,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
 
     @Override
     @Transactional
-    public Exchange exchangeTeacherPoint(PaymentRequestDTO.ExchangeTeacherPointDTO request){
+    public Exchange exchangeTeacherPoints(PaymentRequestDTO.ExchangeTeacherPointsDTO request){
         Member member = authCommandService.getMember();
         if (member.getRole() != Role.TEACHER) throw new MemberHandler(ErrorStatus.MEMBER_ROLE_NOT_TEACHER);
         TeacherInfo teacherInfo = teacherInfoRepository.findByMemberIdAndStatus(member.getId(), Status.ACTIVE)

--- a/src/main/java/kr/co/teacherforboss/validation/annotation/CheckTrueOrFalse.java
+++ b/src/main/java/kr/co/teacherforboss/validation/annotation/CheckTrueOrFalse.java
@@ -18,5 +18,4 @@ public @interface CheckTrueOrFalse {
     String message() default "T 또는 F 값을 입력해주세요.";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
-    int question() default 0;
 }

--- a/src/main/java/kr/co/teacherforboss/validation/annotation/DivisibleBy.java
+++ b/src/main/java/kr/co/teacherforboss/validation/annotation/DivisibleBy.java
@@ -1,0 +1,21 @@
+package kr.co.teacherforboss.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import kr.co.teacherforboss.validation.validator.DivisibleByValidator;
+
+@Documented
+@Constraint(validatedBy = DivisibleByValidator.class)
+@Target( { ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DivisibleBy {
+    String message() default "T 또는 F 값을 입력해주세요.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    double divisor() default 1;
+}

--- a/src/main/java/kr/co/teacherforboss/validation/validator/DivisibleByValidator.java
+++ b/src/main/java/kr/co/teacherforboss/validation/validator/DivisibleByValidator.java
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class DivisibleByValidator implements ConstraintValidator<DivisibleBy, Double> {
+public class DivisibleByValidator implements ConstraintValidator<DivisibleBy, Integer> {
 
     private String message;
-    private Double divisor;
+    private double divisor;
 
     @Override
     public void initialize(DivisibleBy constraintAnnotation) {
@@ -22,7 +22,7 @@ public class DivisibleByValidator implements ConstraintValidator<DivisibleBy, Do
     }
 
     @Override
-    public boolean isValid(Double value, ConstraintValidatorContext context) {
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
         boolean isValid = value != null && value % divisor == 0;
 
         if (!isValid) {

--- a/src/main/java/kr/co/teacherforboss/validation/validator/DivisibleByValidator.java
+++ b/src/main/java/kr/co/teacherforboss/validation/validator/DivisibleByValidator.java
@@ -1,0 +1,36 @@
+package kr.co.teacherforboss.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import kr.co.teacherforboss.validation.annotation.CheckTrueOrFalse;
+import kr.co.teacherforboss.validation.annotation.DivisibleBy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DivisibleByValidator implements ConstraintValidator<DivisibleBy, Double> {
+
+    private String message;
+    private Double divisor;
+
+    @Override
+    public void initialize(DivisibleBy constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        this.message = constraintAnnotation.message();
+        this.divisor = constraintAnnotation.divisor();
+    }
+
+    @Override
+    public boolean isValid(Double value, ConstraintValidatorContext context) {
+        boolean isValid = value != null && value % divisor == 0;
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+        }
+
+        return isValid;
+
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/web/controller/PaymentController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/PaymentController.java
@@ -40,8 +40,8 @@ public class PaymentController {
         return ApiResponse.onSuccess(PaymentConverter.toEditTeacherAccountDTO(teacherInfo));
     }
     @PostMapping("/exchanges")
-    public ApiResponse<PaymentResponseDTO.ExchangeTeacherPointDTO> exchangeTeacherPoint(@RequestBody @Valid PaymentRequestDTO.ExchangeTeacherPointDTO request) {
-        Exchange exchange = paymentCommandService.exchangeTeacherPoint(request);
+    public ApiResponse<PaymentResponseDTO.ExchangeTeacherPointsDTO> exchangeTeacherPoints(@RequestBody @Valid PaymentRequestDTO.ExchangeTeacherPointsDTO request) {
+        Exchange exchange = paymentCommandService.exchangeTeacherPoints(request);
         return ApiResponse.onSuccess(PaymentConverter.toExchangeTeacherPoints(exchange));
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/controller/PaymentController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/PaymentController.java
@@ -40,7 +40,7 @@ public class PaymentController {
         return ApiResponse.onSuccess(PaymentConverter.toEditTeacherAccountDTO(teacherInfo));
     }
     @PostMapping("/exchanges")
-    public ApiResponse<PaymentResponseDTO.ExchangeTeacherPointDTO> exchangeTeacherPoint(@RequestBody PaymentRequestDTO.ExchangeTeacherPointDTO request) {
+    public ApiResponse<PaymentResponseDTO.ExchangeTeacherPointDTO> exchangeTeacherPoint(@RequestBody @Valid PaymentRequestDTO.ExchangeTeacherPointDTO request) {
         Exchange exchange = paymentCommandService.exchangeTeacherPoint(request);
         return ApiResponse.onSuccess(PaymentConverter.toExchangeTeacherPoints(exchange));
     }

--- a/src/main/java/kr/co/teacherforboss/web/controller/PaymentController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/PaymentController.java
@@ -14,6 +14,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,12 +34,12 @@ public class PaymentController {
     }
 
     @PatchMapping("/accounts")
-    public ApiResponse<PaymentResponseDTO.EditTeacherAccountDTO> editTeacherAccount(PaymentRequestDTO.EditTeacherAccountDTO request) {
+    public ApiResponse<PaymentResponseDTO.EditTeacherAccountDTO> editTeacherAccount(@RequestBody PaymentRequestDTO.EditTeacherAccountDTO request) {
         TeacherInfo teacherInfo = paymentCommandService.editTeacherAccount(request);
         return ApiResponse.onSuccess(PaymentConverter.toEditTeacherAccountDTO(teacherInfo));
     }
     @PostMapping("/exchanges")
-    public ApiResponse<PaymentResponseDTO.ExchangeTeacherPointDTO> exchangeTeacherPoint(PaymentRequestDTO.ExchangeTeacherPointDTO request) {
+    public ApiResponse<PaymentResponseDTO.ExchangeTeacherPointDTO> exchangeTeacherPoint(@RequestBody PaymentRequestDTO.ExchangeTeacherPointDTO request) {
         Exchange exchange = paymentCommandService.exchangeTeacherPoint(request);
         return ApiResponse.onSuccess(PaymentConverter.toExchangeTeacherPoints(exchange));
     }

--- a/src/main/java/kr/co/teacherforboss/web/controller/PaymentController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/PaymentController.java
@@ -2,6 +2,7 @@ package kr.co.teacherforboss.web.controller;
 
 import kr.co.teacherforboss.apiPayload.ApiResponse;
 import kr.co.teacherforboss.converter.PaymentConverter;
+import kr.co.teacherforboss.domain.Exchange;
 import kr.co.teacherforboss.domain.TeacherInfo;
 import kr.co.teacherforboss.service.paymentService.PaymentCommandService;
 import kr.co.teacherforboss.service.paymentService.PaymentQueryService;
@@ -12,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -34,5 +36,10 @@ public class PaymentController {
     public ApiResponse<PaymentResponseDTO.EditTeacherAccountDTO> editTeacherAccount(PaymentRequestDTO.EditTeacherAccountDTO request) {
         TeacherInfo teacherInfo = paymentCommandService.editTeacherAccount(request);
         return ApiResponse.onSuccess(PaymentConverter.toEditTeacherAccountDTO(teacherInfo));
+    }
+    @PostMapping("/exchanges")
+    public ApiResponse<PaymentResponseDTO.ExchangeTeacherPointDTO> exchangeTeacherPoint(PaymentRequestDTO.ExchangeTeacherPointDTO request) {
+        Exchange exchange = paymentCommandService.exchangeTeacherPoint(request);
+        return ApiResponse.onSuccess(PaymentConverter.toExchangeTeacherPoint(exchange));
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/controller/PaymentController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/PaymentController.java
@@ -40,6 +40,6 @@ public class PaymentController {
     @PostMapping("/exchanges")
     public ApiResponse<PaymentResponseDTO.ExchangeTeacherPointDTO> exchangeTeacherPoint(PaymentRequestDTO.ExchangeTeacherPointDTO request) {
         Exchange exchange = paymentCommandService.exchangeTeacherPoint(request);
-        return ApiResponse.onSuccess(PaymentConverter.toExchangeTeacherPoint(exchange));
+        return ApiResponse.onSuccess(PaymentConverter.toExchangeTeacherPoints(exchange));
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/PaymentRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/PaymentRequestDTO.java
@@ -11,21 +11,23 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import lombok.extern.jackson.Jacksonized;
 
 public class PaymentRequestDTO {
 
     @Getter
     @Builder
     public static class EditTeacherAccountDTO {
-
         String bank;
         String accountHolder;
         String accountNumber;
     }
 
     @Getter
+    @Jacksonized
     @Builder
     public static class ExchangeTeacherPointDTO {
+        @NotNull
         int points;
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/PaymentRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/PaymentRequestDTO.java
@@ -22,4 +22,10 @@ public class PaymentRequestDTO {
         String accountHolder;
         String accountNumber;
     }
+
+    @Getter
+    @Builder
+    public static class ExchangeTeacherPointDTO {
+        int points;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/PaymentRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/PaymentRequestDTO.java
@@ -35,7 +35,7 @@ public class PaymentRequestDTO {
     @Getter
     @Jacksonized
     @Builder
-    public static class ExchangeTeacherPointDTO {
+    public static class ExchangeTeacherPointsDTO {
 
         @NotNull(message = "포인트를 입력해주세요.")
         @Min(value = 550, message = "550TP 이상부터 교환 가능합니다.")

--- a/src/main/java/kr/co/teacherforboss/web/dto/PaymentRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/PaymentRequestDTO.java
@@ -2,12 +2,14 @@ package kr.co.teacherforboss.web.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import kr.co.teacherforboss.validation.annotation.CheckSurvey;
+import kr.co.teacherforboss.validation.annotation.DivisibleBy;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -34,7 +36,10 @@ public class PaymentRequestDTO {
     @Jacksonized
     @Builder
     public static class ExchangeTeacherPointDTO {
-        @NotNull
-        int points;
+
+        @NotNull(message = "포인트를 입력해주세요.")
+        @Min(value = 550, message = "550TP 이상부터 교환 가능합니다.")
+        @DivisibleBy(divisor = 100, message = "100TP 단위로 교환 가능합니다.")
+        Integer points;
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/PaymentResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/PaymentResponseDTO.java
@@ -25,4 +25,13 @@ public class PaymentResponseDTO {
     public static class EditTeacherAccountDTO {
         LocalDateTime updatedAt;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ExchangeTeacherPointDTO {
+        Long exchangeId;
+        LocalDateTime createdAt;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/PaymentResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/PaymentResponseDTO.java
@@ -30,7 +30,7 @@ public class PaymentResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ExchangeTeacherPointDTO {
+    public static class ExchangeTeacherPointsDTO {
         Long exchangeId;
         LocalDateTime createdAt;
     }

--- a/src/main/resources/templates/exchange.html
+++ b/src/main/resources/templates/exchange.html
@@ -1,0 +1,52 @@
+<!-- 인증 메일 -->
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+</head>
+<body
+        style="
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 20px;
+      background-color: #f9f9f9;
+    "
+>
+<div
+        style="
+        max-width: 600px;
+        margin: 0 auto;
+        background-color: #ffffff;
+        padding: 20px;
+        box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
+      "
+>
+    <h1 style="text-align: center; margin-bottom: 50px">
+        <img
+                src="https://teacherforboss-bucket.s3.ap-northeast-2.amazonaws.com/common/teacherforboss-logo-text.png"
+                alt="logo"
+                style="width: 146px; height: 123px"
+        />
+    </h1>
+    <h1 style="text-align: center; margin: 20px 0; margin-bottom: 50px">
+        &nbsp;티쳐 포 보스 <br> 환전 신청 내역입니다.
+    </h1>
+    <p style="text-align: center; margin: 10px 0; margin-bottom: 50px">
+        &nbsp;본 메일은 <strong th:text="${email}">email </strong> 계정의 환전 신청 내역입니다. <br/>
+        아래 내용을 확인 후 환전 처리 및 티포 환전 완료 신청을 해주시기 바랍니다.
+    </p>
+    <p style="text-align: left; margin: 10px 0; margin-left: 50px; margin-bottom: 50px">
+        - 신청 전 보유하던 티포 : <strong th:text="${ownedTP}">ownedTP </strong> <br/>
+        - 환전 신청 티포 :<strong th:text="${appliedTP}">appliedTP </strong> <br/>
+        - 환전 완료 후 잔여 티포 : <strong th:text="${remainingTP}">remainingTP </strong> <br/>
+        - 수수료 10%(원) : <strong th:text="${charge}">charge </strong> <br/>
+        - 수수료 10%를 제외한 환전 실수령액(원) : <strong th:text="${finalMoney}">finalMoney </strong> <br/>
+        - 계좌번호 : <strong th:text="${accountNumber}">accountNumber </strong> <br/>
+        - 은행 : <strong th:text="${bank}">bank </strong> <br/>
+        - 예금주명 : <strong th:text="${accountHolder}">accountHolder </strong> <br/>
+    </p>
+    <p style="margin: 0">&nbsp;</p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #274 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
![image](https://github.com/user-attachments/assets/9e5d9e7b-0c3b-44a1-8440-e7f9ec3588d9)
![image](https://github.com/user-attachments/assets/dba3c332-bf19-4531-be0f-2ae9280279d6)

- Exchange 엔티티 추가
- TeacherSelectInfo 엔티티 필드명 수정 (point -> points)
- API 호출시 이메일 전송과 함께 보유 포인트 감소

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)
- 550TP 미만 보유시 예외 처리
- 보유 TP보다 더 높은 TP 입력시 예외 처리
- 100TP 단위로 떨어지는 포인트 입력하지 않았을시 예외 처리

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

이메일 전송 -> 포인트 감소 -> Exchange 테이블 업데이트 순으로 로직 구성되는데 괜찮을까요?
그리고 새로운 아이콘 이미지 .. aws에 올라가 있나요??? 그거 받아서 이메일 화면에 보이는 이미지 변경하면 좋을 거 같아요 ㅎㅎ