### PR TITLE
✨[FEAT] 탈퇴한 회원 프로필 조회시 알 수 없음 처리

### DIFF
--- a/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
@@ -491,8 +491,7 @@ public class BoardConverter {
     }
 
     public static BoardResponseDTO.GetQuestionsDTO.QuestionInfo toGetQuestionInfo(Question question, Answer selectedAnswer, boolean liked, boolean bookmarked, Integer answerCount) {
-        boolean isAnswerNull = selectedAnswer == null;
-        boolean isActive = !isAnswerNull && selectedAnswer.getMember().getStatus() == Status.ACTIVE;
+        boolean isActive = selectedAnswer != null && selectedAnswer.getMember().getStatus() == Status.ACTIVE;
 
         return new BoardResponseDTO.GetQuestionsDTO.QuestionInfo(
                 question.getId(),

--- a/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
@@ -19,6 +19,7 @@ import kr.co.teacherforboss.domain.QuestionLike;
 import kr.co.teacherforboss.domain.TeacherInfo;
 import kr.co.teacherforboss.domain.enums.BooleanType;
 import kr.co.teacherforboss.domain.enums.ImageOrigin;
+import kr.co.teacherforboss.domain.enums.Status;
 import kr.co.teacherforboss.web.dto.BoardRequestDTO;
 import kr.co.teacherforboss.web.dto.BoardResponseDTO;
 import kr.co.teacherforboss.web.dto.HomeResponseDTO;
@@ -66,20 +67,25 @@ public class BoardConverter {
     }
 
     public static BoardResponseDTO.MemberInfo toMemberInfo(Member member) {
+        boolean isActive = member.getStatus() == Status.ACTIVE;
+
         return BoardResponseDTO.MemberInfo.builder()
-                .memberId(member.getId())
-                .name(member.getName())
-                .profileImg(member.getProfileImg())
+                .memberId(isActive ? member.getId() : 0)
+                .name(isActive ? member.getName() : "알 수 없음")
+                .profileImg(isActive ? member.getProfileImg() : null)
                 .build();
     }
 
     public static BoardResponseDTO.MemberInfo toMemberInfo(Member member, TeacherInfo teacherInfo) {
+        boolean isActive = member.getStatus() == Status.ACTIVE;
+        TeacherInfo validTeacherInfo = isActive ? teacherInfo : null;
+
         return BoardResponseDTO.MemberInfo.builder()
-                .memberId(member.getId())
-                .name(member.getName())
-                .profileImg(member.getProfileImg())
-                .role(member.getRole())
-                .level((teacherInfo == null) ? null : teacherInfo.getLevel().getLevel())
+                .memberId(isActive ? member.getId() : 0)
+                .name(isActive ? member.getName() : "알 수 없음")
+                .profileImg(isActive ? member.getProfileImg() : null)
+                .role(isActive ? member.getRole() : null)
+                .level((validTeacherInfo != null) ? validTeacherInfo.getLevel().getLevel() : null)
                 .build();
     }
 
@@ -485,13 +491,16 @@ public class BoardConverter {
     }
 
     public static BoardResponseDTO.GetQuestionsDTO.QuestionInfo toGetQuestionInfo(Question question, Answer selectedAnswer, boolean liked, boolean bookmarked, Integer answerCount) {
+        boolean isAnswerNull = selectedAnswer == null;
+        boolean isActive = !isAnswerNull && selectedAnswer.getMember().getStatus() == Status.ACTIVE;
+
         return new BoardResponseDTO.GetQuestionsDTO.QuestionInfo(
                 question.getId(),
                 question.getCategory().getName(),
                 question.getTitle(),
                 question.getContent(),
                 question.getSolved().isIdentifier(),
-                (selectedAnswer == null) ? null : selectedAnswer.getMember().getProfileImg(),
+                isActive ? selectedAnswer.getMember().getProfileImg() : null,
                 question.getBookmarkCount(),
                 answerCount,
                 question.getLikeCount(),


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #301 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

커뮤니티 게시글에서 탈퇴한 회원이 작성한 게시물/댓글의 경우 프로필 이미지 null, 닉네임 알 수 없음 처리 진행했습니다

![image](https://github.com/user-attachments/assets/8dc92cfe-ce27-4315-8c81-68bacfcd0882)
티쳐톡 게시물 예시입니다 ~~ (id = 140)

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
