### PR TITLE
🐛 [FIX] 보스톡/티쳐톡 조회수 증가 & 동시성 제어

### DIFF
--- a/src/main/java/kr/co/teacherforboss/TeacherforbossApplication.java
+++ b/src/main/java/kr/co/teacherforboss/TeacherforbossApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableCaching
+@EnableScheduling
 public class TeacherforbossApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kr/co/teacherforboss/domain/Post.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Post.java
@@ -81,9 +81,8 @@ public class Post extends BaseEntity {
         this.hashtags.add(postHashtag);
     }
 
-    public Post increaseViewCount() {
-        this.viewCount += 1;
-        return this;
+    public void increaseViewCount(Integer viewCount) {
+        this.viewCount = viewCount;
     }
 
     public Post updateLikeCount(boolean isLike) {


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #295 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

우선 현재 보스톡 게시물 조회 관해서 작업 진행했고, 스케줄러 배치 돌릴 때 제 로컬에서는 `Caused by: io.lettuce.core.RedisCommandExecutionException: ERR wrong number of arguments for 'spop' command` 에러가 발생해서,, 이게 Redis 버전 문제인지 keyList (set) 조회할 때 npe 문제인지는 계속 찾는 중입니다. 먼저 PR 올려두고 계속 해결해보겠습니다! 작성한 메서드들 ,,,도 구현 다하면 리팩토링 해야할 거 같아용 ㅎㅎ..
Post의 엔티티 메서드 `increaseViewCount`의 경우 조회할 때마다 DB에 1씩 증가시키는 것에서 Redis에서 모아 한꺼번에 커밋할 조회수 값을 바로 저장하게끔 수정하였습니다~~


다음과 같은 기준으로 Redis에 저장됩니다.

✅ key - value 구조
1. key : 게시글 id , value : 조회수 (누적 포함)
2. key : 유저들이 조회한 게시글 id 리스트 , value : 게시글 id
3. key : 유저 id , value : 해당 유저가 한번 이상 조회한 게시물 id (조회수 중복 방지)


✅ insertPostView 저장 로직

1. redis에 memberId로 저장된 key값 존재 여부를 viewCount로 식별
2. viewCount가 null이라면 (현재 member가 5분간 게시글 처음 조회했다면), 조회한 게시물 id value값으로 저장 (여러 개 조회했다면 _을 delimiter로 저장)
3. viewCount가 null이 아니라면 memberId value에 저장되어 있는 게시물 리스트 조회
 - 5분 동안 방문한 게시물이 이미 있다면, 기존에 5분 내로 방문했던 게시물인지 체크
 - 이미 조회했던 것이라면 for문 break
 - 처음 조회하는 것이라면 redis에 memberId: 조회한 postId 추가


이렇게 저장되면 아래와 같이 볼 수 있는데,

![image](https://github.com/user-attachments/assets/2d0127bd-6187-41d6-8bc7-72228416d578)

* 현재 memberId = 4가 postId = 6을 조회한 상황

✅ keys * 입력했을 때
1) 조회한 게시물 id + post (어떤 게시물이 조회되었는지 보기 위함
2) memberId (어떤 유저가 조회했는지 확인하기 위함)
3) keyList (조회된 게시물 리스트 저장된 set)

✅ smembers keyList 입력했을 때
1) 현재 조회된 postId 6 저장됨



## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

1. 현재 redisUtil에 redis crud 메서드를 추가로 작성해둔 상태인데,, 게시물 조회 관련해서 따로 뺄까요? 혹은 이대로 둘까요?
2. BoardQueryServiceImpl 에 insertPostView, combineViewCount와 같이 조회수 증가와 스케줄러 관련 메서드를 추가했는데 따로 클래스로 뽑아내서 정리해둘지 고민입니다! 
