### PR TITLE
♻️ [REFACTOR] Bookmark & Like 컬럼 수정

### DIFF
--- a/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
@@ -200,41 +200,41 @@ public class BoardConverter {
                 .build();
     }
 
-    public static PostBookmark toSavePostBookmark(Post post, Member member) {
+    public static PostBookmark toPostBookmark(Post post, Member member) {
         return PostBookmark.builder()
-                .bookmarked(BooleanType.F)
                 .member(member)
                 .post(post)
+                .status(Status.ACTIVE)
                 .build();
     }
 
     public static BoardResponseDTO.TogglePostBookmarkDTO toTogglePostBookmarkDTO(PostBookmark bookmark) {
+        boolean bookmarkStatus = (bookmark != null ? BooleanType.T : BooleanType.F).isIdentifier();
         return BoardResponseDTO.TogglePostBookmarkDTO.builder()
-                .bookmark(bookmark.getBookmarked().isIdentifier())
-                .updatedAt(bookmark.getUpdatedAt())
+                .bookmark(bookmarkStatus)
                 .build();
     }
 
     public static PostLike toPostLike(Post post, Member member) {
         return PostLike.builder()
-                .liked(BooleanType.F)
                 .member(member)
                 .post(post)
+                .status(Status.ACTIVE)
                 .build();
     }
 
     public static QuestionLike toQuestionLike(Question question, Member member) {
         return QuestionLike.builder()
-                .liked(BooleanType.F)
                 .member(member)
                 .question(question)
+                .status(Status.ACTIVE)
                 .build();
     }
 
     public static BoardResponseDTO.TogglePostLikeDTO toTogglePostLikeDTO(PostLike like) {
+        boolean likeStatus = (like != null ? BooleanType.T : BooleanType.F).isIdentifier();
         return BoardResponseDTO.TogglePostLikeDTO.builder()
-                .like(like.getLiked().isIdentifier())
-                .updatedAt(like.getUpdatedAt())
+                .like(likeStatus)
                 .build();
     }
 
@@ -285,11 +285,12 @@ public class BoardConverter {
                 .build();
     }
 
-    public static BoardResponseDTO.ToggleQuestionLikeDTO toToggleQuestionLikeDTO(QuestionLike questionLike) {
+    public static BoardResponseDTO.ToggleQuestionLikeDTO toToggleQuestionLikeDTO(QuestionLike like) {
+        long questionId = like != null ? like.getQuestion().getId() : 0;
+        boolean likeStatus = (like != null ? BooleanType.T : BooleanType.F).isIdentifier();
         return BoardResponseDTO.ToggleQuestionLikeDTO.builder()
-                .questionId(questionLike.getQuestion().getId())
-                .liked(questionLike.getLiked().isIdentifier())
-                .updatedAt(questionLike.getUpdatedAt())
+                .questionId(questionId)
+                .liked(likeStatus)
                 .build();
     }
 
@@ -304,19 +305,22 @@ public class BoardConverter {
         return QuestionBookmark.builder()
                 .question(questionToBookmark)
                 .member(member)
-                .bookmarked(BooleanType.F)
+                .status(Status.ACTIVE)
                 .build();
     }
 
-    public static BoardResponseDTO.ToggleQuestionBookmarkDTO toToggleQuestionBookmarkDTO(QuestionBookmark questionBookmark) {
+    public static BoardResponseDTO.ToggleQuestionBookmarkDTO toToggleQuestionBookmarkDTO(QuestionBookmark bookmark) {
+        long questionId = bookmark != null ? bookmark.getQuestion().getId() : 0;
+        boolean bookmarkStatus = (bookmark != null ? BooleanType.T : BooleanType.F).isIdentifier();
         return BoardResponseDTO.ToggleQuestionBookmarkDTO.builder()
-                .questionId(questionBookmark.getQuestion().getId())
-                .bookmarked(questionBookmark.getBookmarked().isIdentifier())
-                .updatedAt(questionBookmark.getUpdatedAt())
+                .questionId(questionId)
+                .bookmarked(bookmarkStatus)
                 .build();
     }
 
     public static BoardResponseDTO.GetQuestionDTO toGetQuestionDTO(Question question, QuestionLike liked, QuestionBookmark bookmarked, boolean isMine) {
+        boolean likeStatus = (liked != null ? BooleanType.T : BooleanType.F).isIdentifier();
+        boolean bookmarkStatus = (bookmarked != null ? BooleanType.T : BooleanType.F).isIdentifier();
         return BoardResponseDTO.GetQuestionDTO.builder()
                 .title(question.getTitle())
                 .content(question.getContent())
@@ -324,8 +328,8 @@ public class BoardConverter {
                 .imageUrlList(toImageUrlList(ImageOrigin.QUESTION.getValue(), question.getImageUuid(), question.getImageIndex()))
                 .hashtagList(toQuestionHashtags(question))
                 .memberInfo(toMemberInfo(question.getMember()))
-                .liked(liked != null && liked.getLiked().isIdentifier())
-                .bookmarked(bookmarked != null && bookmarked.getBookmarked().isIdentifier())
+                .liked(likeStatus)
+                .bookmarked(bookmarkStatus)
                 .likeCount(question.getLikeCount())
                 .bookmarkCount(question.getBookmarkCount())
                 .createdAt(question.getCreatedAt())
@@ -516,8 +520,8 @@ public class BoardConverter {
             Answer selectedAnswer = selectedAnswerMap.getOrDefault(question.getId(), null);
             QuestionLike questionLike = questionLikeMap.get(question.getId());
             QuestionBookmark questionBookmark = questionBookmarkMap.get(question.getId());
-            boolean liked = questionLike != null && questionLike.getLiked().isIdentifier();
-            boolean bookmarked = questionBookmark != null && questionBookmark.getBookmarked().isIdentifier();
+            boolean liked = (questionLike != null ? BooleanType.T : BooleanType.F).isIdentifier();
+            boolean bookmarked = (questionBookmark != null ? BooleanType.T : BooleanType.F).isIdentifier();
             Integer answerCount = question.getAnswerList().size();
             questionInfos.add(BoardConverter.toGetQuestionInfo(question, selectedAnswer, liked, bookmarked, answerCount));
         });

--- a/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/BoardConverter.java
@@ -204,7 +204,6 @@ public class BoardConverter {
         return PostBookmark.builder()
                 .member(member)
                 .post(post)
-                .status(Status.ACTIVE)
                 .build();
     }
 
@@ -219,7 +218,6 @@ public class BoardConverter {
         return PostLike.builder()
                 .member(member)
                 .post(post)
-                .status(Status.ACTIVE)
                 .build();
     }
 
@@ -227,7 +225,6 @@ public class BoardConverter {
         return QuestionLike.builder()
                 .member(member)
                 .question(question)
-                .status(Status.ACTIVE)
                 .build();
     }
 
@@ -305,7 +302,6 @@ public class BoardConverter {
         return QuestionBookmark.builder()
                 .question(questionToBookmark)
                 .member(member)
-                .status(Status.ACTIVE)
                 .build();
     }
 

--- a/src/main/java/kr/co/teacherforboss/domain/Post.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Post.java
@@ -86,8 +86,8 @@ public class Post extends BaseEntity {
         return this;
     }
 
-    public Post updateLikeCount(boolean isLike) {
-        if (isLike) {
+    public Post updateLikeCount(PostLike postLike) {
+        if (postLike != null) {
             this.likeCount += 1;
         } else {
             this.likeCount -= 1;
@@ -95,8 +95,8 @@ public class Post extends BaseEntity {
         return this;
     }
 
-    public Post updateBookmarkCount(boolean isBookmark) {
-        if (isBookmark) {
+    public Post updateBookmarkCount(PostBookmark bookmark) {
+        if (bookmark != null) {
             this.bookmarkCount += 1;
         } else {
             this.bookmarkCount -= 1;

--- a/src/main/java/kr/co/teacherforboss/domain/PostBookmark.java
+++ b/src/main/java/kr/co/teacherforboss/domain/PostBookmark.java
@@ -1,27 +1,41 @@
 package kr.co.teacherforboss.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.validation.constraints.NotNull;
-import kr.co.teacherforboss.domain.common.BaseEntity;
-import kr.co.teacherforboss.domain.enums.BooleanType;
+import kr.co.teacherforboss.domain.enums.Status;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class PostBookmark extends BaseEntity {
+@EntityListeners(AuditingEntityListener.class)
+public class PostBookmark {
+    @Id
+    @Column(nullable = false, updatable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
+    private Long id;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "postId")
     private Post post;
@@ -30,13 +44,14 @@ public class PostBookmark extends BaseEntity {
     @JoinColumn(name = "memberId")
     private Member member;
 
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    @ColumnDefault("'F'")
-    private BooleanType bookmarked;
+    @Column(updatable = false, nullable = false)
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @CreatedDate
+    @Getter
+    private LocalDateTime createdAt;
 
-    public void toggleBookmarked() {
-        if (this.bookmarked.equals(BooleanType.T)) this.bookmarked = BooleanType.F;
-        else this.bookmarked = BooleanType.T;
-    }
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Getter
+    private Status status = Status.ACTIVE;
 }

--- a/src/main/java/kr/co/teacherforboss/domain/PostBookmark.java
+++ b/src/main/java/kr/co/teacherforboss/domain/PostBookmark.java
@@ -53,5 +53,6 @@ public class PostBookmark {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @Getter
+    @Builder.Default
     private Status status = Status.ACTIVE;
 }

--- a/src/main/java/kr/co/teacherforboss/domain/PostLike.java
+++ b/src/main/java/kr/co/teacherforboss/domain/PostLike.java
@@ -53,5 +53,6 @@ public class PostLike {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @Getter
+    @Builder.Default
     private Status status = Status.ACTIVE;
 }

--- a/src/main/java/kr/co/teacherforboss/domain/PostLike.java
+++ b/src/main/java/kr/co/teacherforboss/domain/PostLike.java
@@ -1,27 +1,41 @@
 package kr.co.teacherforboss.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.validation.constraints.NotNull;
-import kr.co.teacherforboss.domain.common.BaseEntity;
-import kr.co.teacherforboss.domain.enums.BooleanType;
+import kr.co.teacherforboss.domain.enums.Status;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class PostLike extends BaseEntity {
+@EntityListeners(AuditingEntityListener.class)
+public class PostLike {
+    @Id
+    @Column(nullable = false, updatable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
+    private Long id;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "postId")
     private Post post;
@@ -30,13 +44,14 @@ public class PostLike extends BaseEntity {
     @JoinColumn(name = "memberId")
     private Member member;
 
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    @ColumnDefault("'F'")
-    private BooleanType liked;
+    @Column(updatable = false, nullable = false)
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @CreatedDate
+    @Getter
+    private LocalDateTime createdAt;
 
-    public void toggleLiked() {
-        if (this.liked.equals(BooleanType.T)) this.liked = BooleanType.F;
-        else this.liked = BooleanType.T;
-    }
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Getter
+    private Status status = Status.ACTIVE;
 }

--- a/src/main/java/kr/co/teacherforboss/domain/Question.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Question.java
@@ -111,8 +111,8 @@ public class Question extends BaseEntity {
         return this.getCreatedAt().plusDays(7).isBefore(now());
     }
 
-    public Question updateLikeCount(boolean isLike) {
-        if (isLike) {
+    public Question updateLikeCount(QuestionLike like) {
+        if (like != null) {
             this.likeCount += 1;
         } else {
             this.likeCount -= 1;
@@ -120,8 +120,8 @@ public class Question extends BaseEntity {
         return this;
     }
 
-    public Question updateBookmarkCount(boolean isBookmark) {
-        if (isBookmark) {
+    public Question updateBookmarkCount(QuestionBookmark bookmark) {
+        if (bookmark != null) {
             this.bookmarkCount += 1;
         } else {
             this.bookmarkCount -= 1;

--- a/src/main/java/kr/co/teacherforboss/domain/QuestionBookmark.java
+++ b/src/main/java/kr/co/teacherforboss/domain/QuestionBookmark.java
@@ -1,27 +1,41 @@
 package kr.co.teacherforboss.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.validation.constraints.NotNull;
-import kr.co.teacherforboss.domain.common.BaseEntity;
-import kr.co.teacherforboss.domain.enums.BooleanType;
+import kr.co.teacherforboss.domain.enums.Status;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class QuestionBookmark extends BaseEntity {
+@EntityListeners(AuditingEntityListener.class)
+public class QuestionBookmark {
+    @Id
+    @Column(nullable = false, updatable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
+    private Long id;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "questionId")
     private Question question;
@@ -30,13 +44,14 @@ public class QuestionBookmark extends BaseEntity {
     @JoinColumn(name = "memberId")
     private Member member;
 
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    @ColumnDefault("'F'")
-    private BooleanType bookmarked;
+    @Column(updatable = false, nullable = false)
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @CreatedDate
+    @Getter
+    private LocalDateTime createdAt;
 
-    public void toggleLiked() {
-        if (this.bookmarked.equals(BooleanType.T)) this.bookmarked = BooleanType.F;
-        else this.bookmarked = BooleanType.T;
-    }
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Getter
+    private Status status = Status.ACTIVE;
 }

--- a/src/main/java/kr/co/teacherforboss/domain/QuestionBookmark.java
+++ b/src/main/java/kr/co/teacherforboss/domain/QuestionBookmark.java
@@ -53,5 +53,6 @@ public class QuestionBookmark {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @Getter
+    @Builder.Default
     private Status status = Status.ACTIVE;
 }

--- a/src/main/java/kr/co/teacherforboss/domain/QuestionLike.java
+++ b/src/main/java/kr/co/teacherforboss/domain/QuestionLike.java
@@ -1,27 +1,41 @@
 package kr.co.teacherforboss.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.validation.constraints.NotNull;
-import kr.co.teacherforboss.domain.common.BaseEntity;
-import kr.co.teacherforboss.domain.enums.BooleanType;
+import kr.co.teacherforboss.domain.enums.Status;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class QuestionLike extends BaseEntity {
+@EntityListeners(AuditingEntityListener.class)
+public class QuestionLike {
+    @Id
+    @Column(nullable = false, updatable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
+    private Long id;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "questionId")
     private Question question;
@@ -30,13 +44,14 @@ public class QuestionLike extends BaseEntity {
     @JoinColumn(name = "memberId")
     private Member member;
 
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    @ColumnDefault("'F'")
-    private BooleanType liked;
+    @Column(updatable = false, nullable = false)
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @CreatedDate
+    @Getter
+    private LocalDateTime createdAt;
 
-    public void toggleLiked() {
-        if (this.liked.equals(BooleanType.T)) this.liked = BooleanType.F;
-        else this.liked = BooleanType.T;
-    }
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Getter
+    private Status status = Status.ACTIVE;
 }

--- a/src/main/java/kr/co/teacherforboss/domain/QuestionLike.java
+++ b/src/main/java/kr/co/teacherforboss/domain/QuestionLike.java
@@ -53,5 +53,6 @@ public class QuestionLike {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @Getter
+    @Builder.Default
     private Status status = Status.ACTIVE;
 }

--- a/src/main/java/kr/co/teacherforboss/repository/PostBookmarkRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/PostBookmarkRepository.java
@@ -24,6 +24,5 @@ public interface PostBookmarkRepository extends JpaRepository<PostBookmark, Long
         WHERE post_id = :postId
     """, nativeQuery = true)
     void softDeletePostBookmarksByPostId(@Param(value = "postId") Long postId);
-
-    long countByMemberIdAndBookmarkedAndStatus(Long memberId, BooleanType bookmarked, Status status);
+    long countByMemberIdAndStatus(Long memberId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/QuestionBookmarkRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/QuestionBookmarkRepository.java
@@ -14,5 +14,5 @@ import java.util.Optional;
 public interface QuestionBookmarkRepository extends JpaRepository<QuestionBookmark, Long> {
 	Optional<QuestionBookmark> findByQuestionIdAndMemberIdAndStatus(Long questionId, Long memberId, Status status);
 	List<QuestionBookmark> findByQuestionInAndMemberIdAndStatus(List<Question> questions, Long memberId, Status status);
-    long countByMemberIdAndBookmarkedAndStatus(Long memberId, BooleanType bookmarked, Status status);
+    long countByMemberIdAndStatus(Long memberId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandService.java
@@ -11,22 +11,23 @@ import kr.co.teacherforboss.domain.PostLike;
 import kr.co.teacherforboss.domain.QuestionBookmark;
 import kr.co.teacherforboss.domain.QuestionLike;
 import kr.co.teacherforboss.web.dto.BoardRequestDTO;
+import kr.co.teacherforboss.web.dto.BoardResponseDTO;
 
 public interface BoardCommandService {
     Post savePost(BoardRequestDTO.SavePostDTO request);
     Post editPost(Long postId, BoardRequestDTO.SavePostDTO request);
     Question saveQuestion(BoardRequestDTO.SaveQuestionDTO request);
-    PostBookmark togglePostBookmark(Long postId);
-    PostLike togglePostLike(Long postId);
+    BoardResponseDTO.TogglePostBookmarkDTO togglePostBookmark(Long postId);
+    BoardResponseDTO.TogglePostLikeDTO togglePostLike(Long postId);
     Post deletePost(Long postId);
     Question editQuestion(Long questionId, BoardRequestDTO.EditQuestionDTO request);
     Answer saveAnswer(long questionId, BoardRequestDTO.SaveAnswerDTO request);
     Answer editAnswer(Long questionId, Long answerId, BoardRequestDTO.EditAnswerDTO request);
     Question deleteQuestion(Long questionId);
-    QuestionLike toggleQuestionLike(Long questionId);
+    BoardResponseDTO.ToggleQuestionLikeDTO toggleQuestionLike(Long questionId);
     AnswerLike toggleAnswerLike(Long questionId, Long answerId, boolean isLike);
     Answer deleteAnswer(Long questionId, Long answerId);
-    QuestionBookmark toggleQuestionBookmark(Long questionId);
+    BoardResponseDTO.ToggleQuestionBookmarkDTO toggleQuestionBookmark(Long questionId);
     Answer selectAnswer(Long questionId, Long answerId);
     CommentLike toggleCommentLike(Long postId, Long commentId, boolean isLike);
     Comment saveComment(Long postId, BoardRequestDTO.SaveCommentDTO request);

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
@@ -14,6 +14,7 @@ import kr.co.teacherforboss.repository.QuestionLikeRepository;
 import kr.co.teacherforboss.domain.AnswerLike;
 import kr.co.teacherforboss.repository.AnswerLikeRepository;
 import kr.co.teacherforboss.repository.TeacherSelectInfoRepository;
+import kr.co.teacherforboss.web.dto.BoardResponseDTO;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -156,29 +157,46 @@ public class BoardCommandServiceImpl implements BoardCommandService {
 
     @Override
     @Transactional
-    public PostBookmark togglePostBookmark(Long postId) {
+    public BoardResponseDTO.TogglePostBookmarkDTO togglePostBookmark(Long postId) {
         Member member = authCommandService.getMember();
         Post post = postRepository.findByIdAndStatus(postId, Status.ACTIVE)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.POST_NOT_FOUND));
-        PostBookmark postBookmark = postBookmarkRepository.findByPostIdAndMemberIdAndStatus(post.getId(), member.getId(), Status.ACTIVE)
-                .orElse(BoardConverter.toSavePostBookmark(post, member));
 
-        postBookmark.toggleBookmarked();
-        post.updateBookmarkCount(postBookmark.getBookmarked().isIdentifier());
-        return postBookmarkRepository.save(postBookmark);
+        PostBookmark postBookmark = postBookmarkRepository.findByPostIdAndMemberIdAndStatus(post.getId(), member.getId(), Status.ACTIVE)
+                .orElse(null);
+
+        if (postBookmark != null) {
+            postBookmarkRepository.delete(postBookmark);
+            postBookmark = null;
+        } else {
+            postBookmark = BoardConverter.toPostBookmark(post, member);
+            postBookmarkRepository.save(postBookmark);
+        }
+
+        post.updateBookmarkCount(postBookmark);
+        return BoardConverter.toTogglePostBookmarkDTO(postBookmark);
     }
 
     @Override
     @Transactional
-    public PostLike togglePostLike(Long postId) {
+    public BoardResponseDTO.TogglePostLikeDTO togglePostLike(Long postId) {
         Member member = authCommandService.getMember();
         Post post = postRepository.findByIdAndStatus(postId, Status.ACTIVE)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.POST_NOT_FOUND));
+
         PostLike postLike = postLikeRepository.findByPostIdAndMemberIdAndStatus(post.getId(), member.getId(), Status.ACTIVE)
-                        .orElse(BoardConverter.toPostLike(post, member));
-        postLike.toggleLiked();
-        post.updateLikeCount(postLike.getLiked().isIdentifier());
-        return postLikeRepository.save(postLike);
+                .orElse(null);
+
+        if (postLike != null) {
+            postLikeRepository.delete(postLike);
+            postLike = null;
+        } else {
+            postLike = BoardConverter.toPostLike(post, member);
+            postLikeRepository.save(postLike);
+        }
+
+        post.updateLikeCount(postLike);
+        return BoardConverter.toTogglePostLikeDTO(postLike);
     }
 
     @Override
@@ -267,16 +285,24 @@ public class BoardCommandServiceImpl implements BoardCommandService {
 
     @Override
     @Transactional
-    public QuestionLike toggleQuestionLike(Long questionId) {
+    public BoardResponseDTO.ToggleQuestionLikeDTO toggleQuestionLike(Long questionId) {
         Member member = authCommandService.getMember();
         Question question = questionRepository.findByIdAndStatus(questionId, Status.ACTIVE)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.QUESTION_NOT_FOUND));
-        QuestionLike questionLike = questionLikeRepository.findByQuestionIdAndMemberIdAndStatus(question.getId(), member.getId(), Status.ACTIVE)
-                .orElse(BoardConverter.toQuestionLike(question, member));
 
-        questionLike.toggleLiked();
-        question.updateLikeCount(questionLike.getLiked().isIdentifier());
-        return questionLikeRepository.save(questionLike);
+        QuestionLike questionLike = questionLikeRepository.findByQuestionIdAndMemberIdAndStatus(question.getId(), member.getId(), Status.ACTIVE)
+                .orElse(null);
+
+        if (questionLike != null) {
+            questionLikeRepository.delete(questionLike);
+            questionLike = null;
+        } else {
+            questionLike = BoardConverter.toQuestionLike(question, member);
+            questionLikeRepository.save(questionLike);
+        }
+
+        question.updateLikeCount(questionLike);
+        return BoardConverter.toToggleQuestionLikeDTO(questionLike);
     }
 
     @Override
@@ -292,16 +318,24 @@ public class BoardCommandServiceImpl implements BoardCommandService {
 
     @Override
     @Transactional
-    public QuestionBookmark toggleQuestionBookmark(Long questionId) {
+    public BoardResponseDTO.ToggleQuestionBookmarkDTO toggleQuestionBookmark(Long questionId) {
         Member member = authCommandService.getMember();
         Question question = questionRepository.findByIdAndStatus(questionId, Status.ACTIVE)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.QUESTION_NOT_FOUND));
-        QuestionBookmark questionBookmark = questionBookmarkRepository.findByQuestionIdAndMemberIdAndStatus(question.getId(), member.getId(), Status.ACTIVE)
-                .orElse(BoardConverter.toQuestionBookmark(question, member));
 
-        questionBookmark.toggleLiked();
-        question.updateBookmarkCount(questionBookmark.getBookmarked().isIdentifier());
-        return questionBookmarkRepository.save(questionBookmark);
+        QuestionBookmark questionBookmark = questionBookmarkRepository.findByQuestionIdAndMemberIdAndStatus(question.getId(), member.getId(), Status.ACTIVE)
+                .orElse(null);
+
+        if (questionBookmark != null) {
+            questionBookmarkRepository.delete(questionBookmark);
+            questionBookmark = null;
+        } else {
+            questionBookmark = BoardConverter.toQuestionBookmark(question, member);
+            questionBookmarkRepository.save(questionBookmark);
+        }
+
+        question.updateBookmarkCount(questionBookmark);
+        return BoardConverter.toToggleQuestionBookmarkDTO(questionBookmark);
     }
 
     @Override

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardQueryServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import kr.co.teacherforboss.domain.enums.BooleanType;
 import kr.co.teacherforboss.domain.enums.Role;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -27,7 +28,6 @@ import kr.co.teacherforboss.domain.QuestionBookmark;
 import kr.co.teacherforboss.domain.QuestionLike;
 import kr.co.teacherforboss.domain.TeacherInfo;
 import kr.co.teacherforboss.domain.common.BaseEntity;
-import kr.co.teacherforboss.domain.enums.BooleanType;
 import kr.co.teacherforboss.domain.enums.QuestionCategory;
 import kr.co.teacherforboss.domain.enums.Status;
 import kr.co.teacherforboss.repository.AnswerLikeRepository;
@@ -76,14 +76,10 @@ public class BoardQueryServiceImpl implements BoardQueryService {
         boolean isMine = member.equals(post.getMember());
 
         PostLike postLike = postLikeRepository.findByPostIdAndMemberIdAndStatus(post.getId(), member.getId(), Status.ACTIVE).orElse(null);
-        if (postLike != null) {
-            liked = postLike.getLiked().isIdentifier();
-        }
+        if (postLike != null) liked = BooleanType.T.isIdentifier();
 
         PostBookmark postBookmark = postBookmarkRepository.findByPostIdAndMemberIdAndStatus(post.getId(), member.getId(), Status.ACTIVE).orElse(null);
-        if (postBookmark != null) {
-            bookmarked = postBookmark.getBookmarked().isIdentifier();
-        }
+        if (postBookmark != null) bookmarked = BooleanType.T.isIdentifier();
 
         TeacherInfo teacherInfo = (member.getRole().equals(Role.TEACHER)) ? teacherInfoRepository.findByMemberIdAndStatus(member.getId(), Status.ACTIVE)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.TEACHER_INFO_NOT_FOUND)) : null;
@@ -120,9 +116,9 @@ public class BoardQueryServiceImpl implements BoardQueryService {
                 member.getId(), Status.ACTIVE);
 
         Map<Long, Boolean> postLikeMap = postLikes.stream()
-                .collect(Collectors.toMap(like -> like.getPost().getId(), like -> like.getLiked().isIdentifier()));
+                .collect(Collectors.toMap(like -> like.getPost().getId(), like -> BooleanType.T.isIdentifier()));
         Map<Long, Boolean> postBookmarkMap = postBookmarks.stream()
-                .collect(Collectors.toMap(bookmark -> bookmark.getPost().getId(), bookmark -> bookmark.getBookmarked().isIdentifier()));
+                .collect(Collectors.toMap(bookmark -> bookmark.getPost().getId(), bookmark -> BooleanType.T.isIdentifier()));
 
         // TODO : 좋아요 수, 북마크 수, 조회수 동시성 제어
 
@@ -275,9 +271,9 @@ public class BoardQueryServiceImpl implements BoardQueryService {
                 member.getId(), Status.ACTIVE);
 
         Map<Long, Boolean> postLikeMap = postLikes.stream()
-                .collect(Collectors.toMap(like -> like.getPost().getId(), like -> like.getLiked().isIdentifier()));
+                .collect(Collectors.toMap(like -> like.getPost().getId(), like -> BooleanType.T.isIdentifier()));
         Map<Long, Boolean> postBookmarkMap = postBookmarks.stream()
-                .collect(Collectors.toMap(bookmark -> bookmark.getPost().getId(), bookmark -> bookmark.getBookmarked().isIdentifier()));
+                .collect(Collectors.toMap(bookmark -> bookmark.getPost().getId(), bookmark -> BooleanType.T.isIdentifier()));
 
         // TODO : 좋아요 수, 북마크 수, 조회수 동시성 제어
 

--- a/src/main/java/kr/co/teacherforboss/service/mypageService/MypageQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/mypageService/MypageQueryServiceImpl.java
@@ -96,9 +96,9 @@ public class MypageQueryServiceImpl implements MypageQueryService {
                 member.getId(), Status.ACTIVE);
 
         Map<Long, Boolean> postLikeMap = postLikes.stream()
-                .collect(Collectors.toMap(like -> like.getPost().getId(), like -> like.getLiked().isIdentifier()));
+                .collect(Collectors.toMap(like -> like.getPost().getId(), like -> BooleanType.T.isIdentifier()));
         Map<Long, Boolean> postBookmarkMap = postBookmarks.stream()
-                .collect(Collectors.toMap(bookmark -> bookmark.getPost().getId(), bookmark -> bookmark.getBookmarked().isIdentifier()));
+                .collect(Collectors.toMap(bookmark -> bookmark.getPost().getId(), bookmark -> BooleanType.T.isIdentifier()));
 
         // TODO : 좋아요 수, 북마크 수, 조회수 동시성 제어
 
@@ -122,9 +122,9 @@ public class MypageQueryServiceImpl implements MypageQueryService {
                 member.getId(), Status.ACTIVE);
 
         Map<Long, Boolean> postLikeMap = postLikes.stream()
-                .collect(Collectors.toMap(like -> like.getPost().getId(), like -> like.getLiked().isIdentifier()));
+                .collect(Collectors.toMap(like -> like.getPost().getId(), like -> BooleanType.T.isIdentifier()));
         Map<Long, Boolean> postBookmarkMap = postBookmarks.stream()
-                .collect(Collectors.toMap(bookmark -> bookmark.getPost().getId(), bookmark -> bookmark.getBookmarked().isIdentifier()));
+                .collect(Collectors.toMap(bookmark -> bookmark.getPost().getId(), bookmark -> BooleanType.T.isIdentifier()));
 
         return BoardConverter.toGetPostInfosDTO(postsPage, postLikeMap, postBookmarkMap);
     }
@@ -163,9 +163,9 @@ public class MypageQueryServiceImpl implements MypageQueryService {
                 member.getId(), Status.ACTIVE);
 
         Map<Long, Boolean> postLikeMap = postLikes.stream()
-                .collect(Collectors.toMap(like -> like.getPost().getId(), like -> like.getLiked().isIdentifier()));
+                .collect(Collectors.toMap(like -> like.getPost().getId(), like -> BooleanType.T.isIdentifier()));
         Map<Long, Boolean> postBookmarkMap = postBookmarks.stream()
-                .collect(Collectors.toMap(bookmark -> bookmark.getPost().getId(), bookmark -> bookmark.getBookmarked().isIdentifier()));
+                .collect(Collectors.toMap(bookmark -> bookmark.getPost().getId(), bookmark -> BooleanType.T.isIdentifier()));
 
         return BoardConverter.toGetPostInfosDTO(postsPage, postLikeMap, postBookmarkMap);
     }
@@ -179,8 +179,8 @@ public class MypageQueryServiceImpl implements MypageQueryService {
         long questionCount = 0;
         int points = 0;
         int questionTicketCount = 0;
-        long bookmarkCount = postBookmarkRepository.countByMemberIdAndBookmarkedAndStatus(member.getId(), BooleanType.T, Status.ACTIVE)
-                + questionBookmarkRepository.countByMemberIdAndBookmarkedAndStatus(member.getId(), BooleanType.T, Status.ACTIVE);
+        long bookmarkCount = postBookmarkRepository.countByMemberIdAndStatus(member.getId(), Status.ACTIVE)
+                + questionBookmarkRepository.countByMemberIdAndStatus(member.getId(), Status.ACTIVE);
 
         if (member.getRole() == Role.BOSS) {
             questionCount = questionRepository.countByMemberIdAndStatus(member.getId(), Status.ACTIVE);

--- a/src/main/java/kr/co/teacherforboss/web/controller/BoardController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/BoardController.java
@@ -76,14 +76,12 @@ public class BoardController {
 
     @PostMapping("/boss/posts/{postId}/bookmark")
     public ApiResponse<BoardResponseDTO.TogglePostBookmarkDTO> togglePostBookmark(@PathVariable("postId") Long postId){
-        PostBookmark bookmark = boardCommandService.togglePostBookmark(postId);
-        return ApiResponse.onSuccess(BoardConverter.toTogglePostBookmarkDTO(bookmark));
+        return ApiResponse.onSuccess(boardCommandService.togglePostBookmark(postId));
     }
 
     @PostMapping("/boss/posts/{postId}/likes")
     public ApiResponse<BoardResponseDTO.TogglePostLikeDTO> togglePostLike(@PathVariable("postId") Long postId){
-        PostLike like = boardCommandService.togglePostLike(postId);
-        return ApiResponse.onSuccess(BoardConverter.toTogglePostLikeDTO(like));
+        return ApiResponse.onSuccess(boardCommandService.togglePostLike(postId));
     }
 
     @DeleteMapping("/boss/posts/{postId}")
@@ -113,8 +111,7 @@ public class BoardController {
 
     @PostMapping("/teacher/questions/{questionId}/likes")
     public ApiResponse<BoardResponseDTO.ToggleQuestionLikeDTO> toggleQuestionLike(@PathVariable("questionId") Long questionId) {
-        QuestionLike questionLike = boardCommandService.toggleQuestionLike(questionId);
-        return ApiResponse.onSuccess(BoardConverter.toToggleQuestionLikeDTO(questionLike));
+        return ApiResponse.onSuccess(boardCommandService.toggleQuestionLike(questionId));
     }
 
     @PatchMapping("/teacher/questions/{questionId}/answers/{answerId}")
@@ -134,8 +131,7 @@ public class BoardController {
 
     @PostMapping("/teacher/questions/{questionId}/bookmark")
     public ApiResponse<BoardResponseDTO.ToggleQuestionBookmarkDTO> toggleQuestionBookmark(@PathVariable("questionId") Long questionId) {
-        QuestionBookmark questionBookmark = boardCommandService.toggleQuestionBookmark(questionId);
-        return ApiResponse.onSuccess(BoardConverter.toToggleQuestionBookmarkDTO(questionBookmark));
+        return ApiResponse.onSuccess(boardCommandService.toggleQuestionBookmark(questionId));
     }
 
     @GetMapping("/teacher/questions/{questionId}")

--- a/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/BoardResponseDTO.java
@@ -175,7 +175,6 @@ public class BoardResponseDTO {
     @AllArgsConstructor
     public static class TogglePostBookmarkDTO {
         Boolean bookmark;
-        LocalDateTime updatedAt;
     }
 
     @Getter
@@ -184,7 +183,6 @@ public class BoardResponseDTO {
     @AllArgsConstructor
     public static class TogglePostLikeDTO {
         Boolean like;
-        LocalDateTime updatedAt;
     }
 
     @Getter
@@ -212,7 +210,6 @@ public class BoardResponseDTO {
     public static class ToggleQuestionLikeDTO {
         Long questionId;
         boolean liked;
-        LocalDateTime updatedAt;
     }
 
     @Getter
@@ -255,7 +252,6 @@ public class BoardResponseDTO {
     public static class ToggleQuestionBookmarkDTO {
         Long questionId;
         boolean bookmarked;
-        LocalDateTime updatedAt;
     }
 
     @Getter


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #312 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- db 테이블 컬럼 변경 & 상속 취소
- null 객체로 Converter 들어가면 리턴값으로 Id 0으로 주게했는데 (NPE 땜시) 괜찮을지..
- 동시성 관한 건 그 조회수랑 같이... 하겠습니다
- Converter 함수 메서드 네이밍 변경 (toSavePostBookmark -> toPostBookmark로 기존 것들과 통일)
- 코드가 전반적으로 짜친데.....ㅎ 원래는 findBy~.map(~~delete).orElseGet 이런 식으로 하려고 했거든요??! 그런데 그런 경우 북마크나 좋아요 취소할 때 취소처리가 안돼서.. (BookmarkCount가 1 줄지 않는다든지) 쨋든 이건.. 나중에 차차 리팩토링하거나.. 함 봐주면 땡큐


## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
