### PR TITLE
✨[FEAT] 채택 플로우 수정

### DIFF
--- a/src/main/java/kr/co/teacherforboss/TeacherforbossApplication.java
+++ b/src/main/java/kr/co/teacherforboss/TeacherforbossApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableCaching
+@EnableScheduling
 public class TeacherforbossApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
@@ -4,6 +4,7 @@ import kr.co.teacherforboss.domain.BusinessAuth;
 import kr.co.teacherforboss.domain.Member;
 import kr.co.teacherforboss.domain.EmailAuth;
 import kr.co.teacherforboss.domain.PhoneAuth;
+import kr.co.teacherforboss.domain.TeacherSelectInfo;
 import kr.co.teacherforboss.domain.enums.BooleanType;
 import kr.co.teacherforboss.domain.TeacherInfo;
 import kr.co.teacherforboss.domain.enums.Gender;
@@ -42,7 +43,7 @@ public class AuthConverter {
                 .build();
     }
 
-    public static TeacherInfo toTeacher(AuthRequestDTO.JoinCommonDTO request){
+    public static TeacherInfo toTeacherInfo(AuthRequestDTO.JoinCommonDTO request){
         String keywords = String.join(";", request.getKeywords());
         return TeacherInfo.builder()
                 .businessNumber(request.getBusinessNumber())
@@ -56,6 +57,14 @@ public class AuthConverter {
                 .bank(request.getBank())
                 .accountNumber(AES256Util.encrypt(request.getAccountNumber()))
                 .accountHolder(request.getAccountHolder())
+                .build();
+    }
+
+    public static TeacherSelectInfo toTeacherSelectInfo(Member member){
+        return TeacherSelectInfo.builder()
+                .member(member)
+                .points(TeacherSelectInfo.POINT)
+                .selectCount(TeacherSelectInfo.COUNT)
                 .build();
     }
 

--- a/src/main/java/kr/co/teacherforboss/domain/Answer.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Answer.java
@@ -18,6 +18,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.format.annotation.DateTimeFormat;
 
 @Entity
@@ -26,7 +28,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Answer extends BaseEntity {
-
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "questionId")
     private Question question;

--- a/src/main/java/kr/co/teacherforboss/domain/AnswerLike.java
+++ b/src/main/java/kr/co/teacherforboss/domain/AnswerLike.java
@@ -13,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -20,6 +22,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class AnswerLike extends BaseEntity {
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "answerId")
     private Answer answer;

--- a/src/main/java/kr/co/teacherforboss/domain/Question.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Question.java
@@ -34,7 +34,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class Question extends BaseEntity {
 
-    public final static int POINT = 100;
+    public final static int POINT = 1;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "categoryId")

--- a/src/main/java/kr/co/teacherforboss/domain/QuestionBookmark.java
+++ b/src/main/java/kr/co/teacherforboss/domain/QuestionBookmark.java
@@ -15,6 +15,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -22,6 +24,7 @@ import org.hibernate.annotations.ColumnDefault;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class QuestionBookmark extends BaseEntity {
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "questionId")
     private Question question;

--- a/src/main/java/kr/co/teacherforboss/domain/QuestionHashtag.java
+++ b/src/main/java/kr/co/teacherforboss/domain/QuestionHashtag.java
@@ -10,6 +10,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -17,6 +19,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class QuestionHashtag extends BaseEntity {
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "questionId")
     private Question question;

--- a/src/main/java/kr/co/teacherforboss/domain/QuestionLike.java
+++ b/src/main/java/kr/co/teacherforboss/domain/QuestionLike.java
@@ -15,6 +15,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -22,6 +24,7 @@ import org.hibernate.annotations.ColumnDefault;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class QuestionLike extends BaseEntity {
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "questionId")
     private Question question;

--- a/src/main/java/kr/co/teacherforboss/domain/TeacherSelectInfo.java
+++ b/src/main/java/kr/co/teacherforboss/domain/TeacherSelectInfo.java
@@ -20,6 +20,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class TeacherSelectInfo extends BaseEntity {
 
+    public final static int POINT = 0;
+    public final static int COUNT = 0;
+
     @NotNull
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memberId")

--- a/src/main/java/kr/co/teacherforboss/repository/AnswerRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/AnswerRepository.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Optional;
 import kr.co.teacherforboss.domain.Answer;
 import kr.co.teacherforboss.domain.Question;
-import kr.co.teacherforboss.domain.enums.BooleanType;
 import kr.co.teacherforboss.domain.enums.Status;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -41,4 +40,5 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 	Slice<Answer> findSliceByIdLessThanAndQuestionIdAndStatusOrderByCreatedAtDesc(@Param(value = "lastAnswerId") Long lastAnswerId,
 																				  @Param(value = "questionId") Long questionId,
 																				  Pageable pageable);
+	Optional<Answer> findTopByQuestionIdAndSelectedAtIsNullAndStatusOrderByLikeCountDescDislikeCountAscCreatedAtAsc(Long questionId, Status status);
 }

--- a/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
+++ b/src/main/java/kr/co/teacherforboss/repository/QuestionRepository.java
@@ -161,4 +161,11 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
   		ORDER BY id DESC
   	""", nativeQuery = true)
 	Slice<Question> findBookmarkedQuestionsSliceByIdLessThanAndMemberIdOrderByCreatedAtDesc(Long questionId, Long memberId, PageRequest pageRequest);
+	@Query(value = """
+			SELECT * FROM question
+			WHERE DATE_ADD(created_at, INTERVAL 7 DAY) <= NOW()
+			AND solved = 'F'
+			AND status = 'ACTIVE';
+			""", nativeQuery = true)
+	List<Question> findByExpiredDate();
 }

--- a/src/main/java/kr/co/teacherforboss/scheduler/QuestionScheduler.java
+++ b/src/main/java/kr/co/teacherforboss/scheduler/QuestionScheduler.java
@@ -1,0 +1,53 @@
+package kr.co.teacherforboss.scheduler;
+
+import kr.co.teacherforboss.apiPayload.code.status.ErrorStatus;
+import kr.co.teacherforboss.apiPayload.exception.handler.BoardHandler;
+import kr.co.teacherforboss.domain.Answer;
+import kr.co.teacherforboss.domain.Question;
+import kr.co.teacherforboss.domain.TeacherSelectInfo;
+import kr.co.teacherforboss.domain.enums.Status;
+import kr.co.teacherforboss.repository.AnswerRepository;
+import kr.co.teacherforboss.repository.QuestionRepository;
+import kr.co.teacherforboss.repository.TeacherSelectInfoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QuestionScheduler {
+    private final QuestionRepository questionRepository;
+    private final AnswerRepository answerRepository;
+    private final TeacherSelectInfoRepository teacherSelectInfoRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void checkExpiredQuestions() {
+    System.out.println("현재 시각은 " + new Date());
+        List<Question> expiredQuestions = questionRepository.findByExpiredDate();
+
+        for (Question question : expiredQuestions) {
+            if (question.getAnswerList().isEmpty()) { // 답변 자동 삭제
+                questionRepository.delete(question);
+                // TODO: 질문권 복구 및 질문글 삭제에 대한 푸시알림 추가
+            } else { // 답변 채택
+                // TODO: 채택된 답변을 단 티쳐 status INACTIVE면 ? -> 연관관계 처리
+                Answer bestAnswer = answerRepository.findTopByQuestionIdAndSelectedAtIsNullAndStatusOrderByLikeCountDescDislikeCountAscCreatedAtAsc(question.getId(), Status.ACTIVE)
+                        .orElseThrow(() -> new BoardHandler(ErrorStatus.ANSWER_NOT_FOUND));
+                System.out.println(bestAnswer.getId());
+                System.out.println(bestAnswer.getQuestion().getId());
+
+                question.selectAnswer(bestAnswer);
+                TeacherSelectInfo teacherSelectInfo = teacherSelectInfoRepository.findByMemberIdAndStatus(bestAnswer.getMember().getId(), Status.ACTIVE)
+                            .orElseThrow(() -> new BoardHandler(ErrorStatus.TEACHER_SELECT_INFO_NOT_FOUND));
+                teacherSelectInfo.increaseSelectCount();
+            }
+        }
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
@@ -94,7 +94,10 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         AgreementTerm newAgreement = AuthConverter.toAgreementTerm(request, newMember);
 
         newMember.setProfile(request.getNickname(), request.getProfileImg());
-        if (Role.of(request.getRole()).equals(Role.TEACHER)) saveTeacherInfo(request);
+        if (Role.of(request.getRole()).equals(Role.TEACHER)) {
+            saveTeacherInfo(request);
+            saveTeacherSelectInfo(newMember);
+        }
 
         agreementTermRepository.save(newAgreement);
         return memberRepository.save(newMember);
@@ -319,8 +322,13 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         if (request.getKeywords().isEmpty())
             throw new AuthHandler(ErrorStatus.MEMBER_KEYWORDS_EMPTY);
 
-        TeacherInfo newTeacher = AuthConverter.toTeacher(request);
+        TeacherInfo newTeacher = AuthConverter.toTeacherInfo(request);
         teacherInfoRepository.save(newTeacher);
+    }
+
+    private void saveTeacherSelectInfo(Member member) {
+        TeacherSelectInfo newTeacher = AuthConverter.toTeacherSelectInfo(member);
+        teacherSelectInfoRepository.save(newTeacher);
     }
 
     private void saveTeacherSelectInfo() {

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardCommandServiceImpl.java
@@ -362,11 +362,11 @@ public class BoardCommandServiceImpl implements BoardCommandService {
         Answer answer = answerRepository.findByIdAndQuestionIdAndStatus(answerId, questionId, Status.ACTIVE)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.ANSWER_NOT_FOUND));
         TeacherSelectInfo teacherSelectInfo = teacherSelectInfoRepository.findByMemberIdAndStatus(answer.getMember().getId(), Status.ACTIVE)
-                .orElseThrow(() -> new BoardHandler(ErrorStatus.TEACHER_SELECT_INFO_NOT_FOUND));  // TODO: teacher 가입할 때 teacherSelectInfo 생성
+                .orElseThrow(() -> new BoardHandler(ErrorStatus.TEACHER_SELECT_INFO_NOT_FOUND));
 
         question.selectAnswer(answer);
         teacherSelectInfo.increaseSelectCount();
-        teacherSelectInfo.addPoints(Question.POINT);
+//        teacherSelectInfo.addPoints(Question.POINT); TODO: 지금은 채택만 되고 TP 지급 안함
 
         return answer;
     }

--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardQueryServiceImpl.java
@@ -27,7 +27,6 @@ import kr.co.teacherforboss.domain.QuestionBookmark;
 import kr.co.teacherforboss.domain.QuestionLike;
 import kr.co.teacherforboss.domain.TeacherInfo;
 import kr.co.teacherforboss.domain.common.BaseEntity;
-import kr.co.teacherforboss.domain.enums.BooleanType;
 import kr.co.teacherforboss.domain.enums.QuestionCategory;
 import kr.co.teacherforboss.domain.enums.Status;
 import kr.co.teacherforboss.repository.AnswerLikeRepository;


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #314 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

![image](https://github.com/user-attachments/assets/d1a4bf71-7c7b-42c0-a52d-6e66f86f710a)

- 채택 시 우선 채택만 되고 TP 지급 안함
- TP 지급 로직은 만들어놓되 주석처리 (스케줄러 돌리기 (매일 자정))
- 답변이 달린 시점부터 일주일간 채택되지 않을 시 자동 채택 (연장 시스템 삭제 & 스케줄러 돌리기 (매일 자정))
- 채택 하는 기준은 위 사진 -> 맞춰서 쿼리 작성
- teacher 가입할 때 teacherSelectInfo 생성
- Question 연관관계에 있는 엔티티에 `on delete cascade` 설정 (QuestionBookmark, QuestionHashtag, QuestionLike, Answer)
- Answer 연관관계에 있는 엔티티에 `on delete cascade` 설정 (AnswerLike)
 
 
## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 스케줄러 돌리는 부분에 알림 TODO 적어뒀습니다
- 스케줄러 돌리는 코드에 답변 채택되는 경우 티쳐 정보 조회하는데 티쳐 status INACTIVE인 경우 롤백되더라구요.. 그래서 그 해당 답변 상태 INACTIVE로 해뒀고, 티쳐 회원탈퇴할 때 답변 상태 변경하는 거 (삭제하거나 INACTIVE로 바꾸거나 ) 이 부분은 나중에 자세히 보려고 TODO 작성해뒀습니다