### PR TITLE
✨[FEAT] 회원가입시 사업자 인증 주석 처리

### DIFF
--- a/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
@@ -47,7 +47,7 @@ public class AuthConverter {
         String keywords = String.join(";", request.getKeywords());
         return TeacherInfo.builder()
                 .member(member)
-                .businessNumber(request.getBusinessNumber())
+//                .businessNumber(request.getBusinessNumber())
                 .representative(request.getRepresentative())
                 .openDate(request.getOpenDate())
                 .field(request.getField())

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
@@ -307,8 +307,8 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     private void saveTeacherInfo(AuthRequestDTO.JoinCommonDTO request, Member member) {
 //         if (!businessAuthRepository.existsByBusinessNumber(request.getBusinessNumber()))
 //             throw new AuthHandler(ErrorStatus.BUSINESS_NUMBER_NOT_CHECKED);
-        if (request.getBusinessNumber() == null)
-            throw new AuthHandler(ErrorStatus.MEMBER_BUSINESS_NUMBER_EMPTY);
+//        if (request.getBusinessNumber() == null)
+//            throw new AuthHandler(ErrorStatus.MEMBER_BUSINESS_NUMBER_EMPTY);
         if (request.getRepresentative() == null)
             throw new AuthHandler(ErrorStatus.MEMBER_REPRESENTATIVE_EMPTY);
         if (request.getOpenDate().toString().isBlank())

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -41,8 +41,8 @@ public class AuthRequestDTO {
 
         String profileImg;
 
-        @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "사업자 등록 번호는 최대 10자 이내로 입력 가능합니다.")
-        String businessNumber;
+//        @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "사업자 등록 번호는 최대 10자 이내로 입력 가능합니다.")
+//        String businessNumber;
 
         @Size(max = 20, message = "대표자명은 최대 20자 이내로 입력 가능합니다.")
         String representative;


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #325 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 회원가입시 사업자 인증 주석 처리
- 주석 처리했을 때 리턴값 명세서 추가
- DB에는 TeacherInfo의 `businessNumber` NotNull 아니어서 엔티티 @NotNull 안지웠어요

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
