### PR TITLE
✨[FEAT] 티쳐 가입 심사 API

### DIFF
--- a/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/kr/co/teacherforboss/apiPayload/code/status/ErrorStatus.java
@@ -73,6 +73,8 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_ROLE_NOT_TEACHER(BAD_REQUEST, "MEMBER40024", "티쳐가 아닙니다."),
     MEMBER_ACCOUNT_INFO_EMPTY(BAD_REQUEST, "MEMBER40025", "계좌 정보를 입력해주세요."),
     MEMBER_ROLE_NOT_ADMIN(BAD_REQUEST, "MEMBER40026", "관리자가 아닙니다."),
+    MEMBER_NOT_UNDER_TEACHER_REVIEW(BAD_REQUEST, "MEMBER40027", "심사 진행 중인 티쳐가 아닙니다."),
+    MEMBER_ALREADY_REVIEWED(BAD_REQUEST, "MEMBER40028", "심사 완료된 티쳐는 가입할 수 없습니다."),
 
     MEMBER_NOT_FOUND(NOT_FOUND, "MEMBER4041", "사용자가 없습니다."),
     TEACHER_INFO_NOT_FOUND(NOT_FOUND, "MEMBER4042", "사용자에 해당되는 티쳐 정보가 없습니다."),

--- a/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
+++ b/src/main/java/kr/co/teacherforboss/converter/AuthConverter.java
@@ -184,4 +184,11 @@ public class AuthConverter {
                 .activeDate(LocalDateTime.now())
                 .build();
     }
+
+    public static AuthResponseDTO.CompleteTeacherSignupDTO toCompleteTeacherSignupDTO(Member member) {
+        return AuthResponseDTO.CompleteTeacherSignupDTO.builder()
+                .memberId(member.getId())
+                .role(member.getRole())
+                .build();
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/domain/Member.java
+++ b/src/main/java/kr/co/teacherforboss/domain/Member.java
@@ -94,6 +94,10 @@ public class Member extends BaseEntity {
         this.profileImg = profileImg;
     }
 
+    public void setRole(Role role) {
+        this.role = role;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/kr/co/teacherforboss/domain/TeacherInfo.java
+++ b/src/main/java/kr/co/teacherforboss/domain/TeacherInfo.java
@@ -33,7 +33,7 @@ public class TeacherInfo extends BaseEntity {
     @JoinColumn(name = "memberId")
     private Member member;
 
-    @NotNull
+//    @NotNull
     @Column(length = 100)
     private String businessNumber;
 

--- a/src/main/java/kr/co/teacherforboss/domain/enums/Role.java
+++ b/src/main/java/kr/co/teacherforboss/domain/enums/Role.java
@@ -9,7 +9,8 @@ public enum Role {
     NONE(0),
     BOSS(1),
     TEACHER(2),
-    ADMIN(3);
+    ADMIN(3),
+    TEACHER_RV(4);
 
     private final int identifier;
 
@@ -17,6 +18,7 @@ public enum Role {
         if (identifier == 1) return BOSS;
         if (identifier == 2) return TEACHER;
         if (identifier == 3) return ADMIN;
+        if (identifier == 4) return TEACHER_RV;
         return NONE;
     }
 }

--- a/src/main/java/kr/co/teacherforboss/domain/vo/mailVO/TeacherAuditMail.java
+++ b/src/main/java/kr/co/teacherforboss/domain/vo/mailVO/TeacherAuditMail.java
@@ -1,0 +1,41 @@
+package kr.co.teacherforboss.domain.vo.mailVO;
+
+import kr.co.teacherforboss.domain.Member;
+import kr.co.teacherforboss.domain.TeacherInfo;
+
+import java.time.format.DateTimeFormatter;
+
+public class TeacherAuditMail extends Mail {
+
+    public TeacherAuditMail(Member member, TeacherInfo teacherInfo) {
+        super("teacher-audit", "[티쳐 포 보스] 티처 심사 요청");
+        super.values.put("phone", getPhone(member));
+        super.values.put("email", getEmail(member));
+        super.values.put("businessNumber", getBusinessNumber(teacherInfo));
+        super.values.put("representative", getRepresentative(teacherInfo));
+        super.values.put("openDate", getOpenDate(teacherInfo));
+        super.values.put("field", getField(teacherInfo));
+        super.values.put("career", getCareer(teacherInfo));
+    }
+
+    private String getPhone(Member member) { return member.getPhone(); }
+    private String getEmail(Member member) {
+        return member.getEmail();
+    }
+    private String getBusinessNumber(TeacherInfo teacherInfo) {
+        return teacherInfo.getBusinessNumber();
+    }
+    private String getRepresentative(TeacherInfo teacherInfo) {
+        return teacherInfo.getRepresentative();
+    }
+    private String getOpenDate(TeacherInfo teacherInfo) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return teacherInfo.getOpenDate().format(formatter);
+    }
+    private String getField(TeacherInfo teacherInfo) {
+         return teacherInfo.getField();
+    }
+    private String getCareer(TeacherInfo teacherInfo) {
+        return teacherInfo.getCareer().toString();
+    }
+}

--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandService.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandService.java
@@ -24,4 +24,5 @@ public interface AuthCommandService {
     BusinessAuth checkBusinessNumber(AuthRequestDTO.CheckBusinessNumberDTO request);
     Member withdraw();
     Member recover(String email);
+    Member completeTeacherSignup(AuthRequestDTO.CompleteTeacherSignupDTO request);
 }

--- a/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/paymentService/PaymentCommandServiceImpl.java
@@ -17,6 +17,7 @@ import kr.co.teacherforboss.service.authService.AuthCommandService;
 import kr.co.teacherforboss.service.mailService.MailCommandService;
 import kr.co.teacherforboss.web.dto.PaymentRequestDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PaymentCommandServiceImpl implements PaymentCommandService {
 
+    @Value("${spring.mail.username}")
+    private String ADMIN_MAIL;
     private final AuthCommandService authCommandService;
     private final MailCommandService mailCommandService;
     private final TeacherInfoRepository teacherInfoRepository;
@@ -54,7 +57,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
         if (request.getPoints() > teacherSelectInfo.getPoints()) throw new PaymentHandler(ErrorStatus.TEACHER_POINT_LIMIT_OVER);
 
         ExchangeMail exchangeMail = new ExchangeMail(teacherSelectInfo.getPoints(), request.getPoints(), teacherInfo);
-        mailCommandService.sendMail(member.getEmail(), exchangeMail);
+        mailCommandService.sendMail(ADMIN_MAIL, exchangeMail);
 
         Exchange exchange = PaymentConverter.toExchange(member, request.getPoints());
         teacherSelectInfo.decreasePoints(request.getPoints());

--- a/src/main/java/kr/co/teacherforboss/web/controller/AuthController.java
+++ b/src/main/java/kr/co/teacherforboss/web/controller/AuthController.java
@@ -4,7 +4,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import kr.co.teacherforboss.apiPayload.ApiResponse;
 import kr.co.teacherforboss.config.jwt.JwtTokenProvider;
-import kr.co.teacherforboss.config.jwt.PrincipalDetails;
 import kr.co.teacherforboss.converter.AuthConverter;
 import kr.co.teacherforboss.domain.BusinessAuth;
 import kr.co.teacherforboss.domain.Member;
@@ -13,14 +12,12 @@ import kr.co.teacherforboss.domain.PhoneAuth;
 import kr.co.teacherforboss.service.authService.AuthCommandService;
 import kr.co.teacherforboss.service.authService.AuthQueryService;
 import kr.co.teacherforboss.validation.annotation.CheckSocialType;
-import kr.co.teacherforboss.validation.annotation.ExistPrincipalDetails;
 import kr.co.teacherforboss.web.dto.AuthRequestDTO;
 import kr.co.teacherforboss.web.dto.AuthResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -140,5 +137,11 @@ public class AuthController {
     public ApiResponse<AuthResponseDTO.RecoverDTO> recover(@RequestHeader("email") String email) {
         Member member = authCommandService.recover(email);
         return ApiResponse.onSuccess(AuthConverter.toRecoverDTO(member));
+    }
+
+    @PatchMapping("/teacher/signup-complete")
+    public ApiResponse<AuthResponseDTO.CompleteTeacherSignupDTO> completeTeacherSignup(@RequestBody @Valid AuthRequestDTO.CompleteTeacherSignupDTO request) {
+        Member member = authCommandService.completeTeacherSignup(request);
+        return ApiResponse.onSuccess(AuthConverter.toCompleteTeacherSignupDTO(member));
     }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthRequestDTO.java
@@ -241,4 +241,13 @@ public class AuthRequestDTO {
         @NotNull(message = "개업연월일이 없습니다.")
         LocalDate openDate;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CompleteTeacherSignupDTO {
+        @NotNull(message = "memberId 값이 없습니다.")
+        Long memberId;
+    }
 }

--- a/src/main/java/kr/co/teacherforboss/web/dto/AuthResponseDTO.java
+++ b/src/main/java/kr/co/teacherforboss/web/dto/AuthResponseDTO.java
@@ -1,6 +1,8 @@
 package kr.co.teacherforboss.web.dto;
 
 import java.time.LocalDateTime;
+
+import kr.co.teacherforboss.domain.enums.Role;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -131,5 +133,14 @@ public class AuthResponseDTO {
     public static class RecoverDTO {
         Long memberId;
         LocalDateTime activeDate;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CompleteTeacherSignupDTO {
+        Long memberId;
+        Role role;
     }
 }

--- a/src/main/resources/templates/teacher-audit.html
+++ b/src/main/resources/templates/teacher-audit.html
@@ -1,0 +1,47 @@
+<!-- 인증 메일 -->
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+</head>
+<body
+        style="
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 20px;
+      background-color: #f9f9f9;
+    "
+>
+<div
+        style="
+        max-width: 600px;
+        margin: 0 auto;
+        background-color: #ffffff;
+        padding: 20px;
+        box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
+      "
+>
+    <h1 style="text-align: center; margin-bottom: 50px">
+        <img
+                src="https://teacherforboss-bucket.s3.ap-northeast-2.amazonaws.com/common/teacherforboss-logo-text.png"
+                alt="logo"
+                style="width: 146px; height: 123px"
+        />
+    </h1>
+    <h1 style="text-align: center; margin: 20px 0; margin-bottom: 50px">
+        &lt;티처 심사 요청&gt;
+    </h1>
+    <p style="text-align: left; margin: 10px 0; margin-left: 50px; margin-bottom: 50px">
+        핸드폰 번호 : <strong th:text="${phone}">phone </strong> <br/>
+        이메일 : <strong th:text="${email}">email </strong> <br/>
+        사업자 등록 번호 : <strong th:text="${businessNumber}">businessNumber </strong> <br/>
+        대표자명 : <strong th:text="${representative}">representative </strong> <br/>
+        개업연월일 : <strong th:text="${openDate}">openDate </strong> <br/>
+        분야 : <strong th:text="${field}">field </strong> <br/>
+        경력 : <strong th:text="${career}">career </strong> <br/>
+    </p>
+    <p style="margin: 0">&nbsp;</p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #324 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 티처로 신규가입하는 회원들 기본 role을 TEACHER_RV로 두기
- 티처 가입 심사 위해 티쳐 현재 role값 (TEACHER_RV) 전달
- 티처로 가입시 관리자 메일 전송
- 관리자 심사 완료 API -> role값 변경
- TeacherInfo의 businessNumber 필드 @NotNull 제거 및 DB 반영

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- uri 괜찮은지 봐주세요
