### PR TITLE
🐛[FIX] 프로필 조회 API 탈퇴한 계정으로 조회되는 거 수정

### DIFF
--- a/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/authService/AuthCommandServiceImpl.java
@@ -232,7 +232,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     @Override
     @Transactional(readOnly = true)
     public Member getMember() {
-        return memberRepository.findByEmail(SecurityUtil.getCurrentUserEmail())
+        return memberRepository.findByEmailAndStatus(SecurityUtil.getCurrentUserEmail(), Status.ACTIVE)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
     }
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #332 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
동일한 이메일로 새로 가입할 때 사용자 없다는 에러 발생
-> 사용자 조회시 (getMember) email + **status** 조건 추가

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
