### PR TITLE
🐛[FIX] 보스톡 게시물 작성자 티쳐시 level 값 null반환 해결

### DIFF
--- a/src/main/java/kr/co/teacherforboss/service/boardService/BoardQueryServiceImpl.java
+++ b/src/main/java/kr/co/teacherforboss/service/boardService/BoardQueryServiceImpl.java
@@ -68,7 +68,7 @@ public class BoardQueryServiceImpl implements BoardQueryService {
         Post post = postRepository.findByIdAndStatus(postId, Status.ACTIVE)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.POST_NOT_FOUND))
                 .increaseViewCount();
-
+        Member writer = post.getMember();
         boolean liked = false;
         boolean bookmarked = false;
         boolean isMine = member.equals(post.getMember());
@@ -83,7 +83,7 @@ public class BoardQueryServiceImpl implements BoardQueryService {
             bookmarked = postBookmark.getBookmarked().isIdentifier();
         }
 
-        TeacherInfo teacherInfo = (member.getRole().equals(Role.TEACHER)) ? teacherInfoRepository.findByMemberIdAndStatus(member.getId(), Status.ACTIVE)
+        TeacherInfo teacherInfo = (writer.getRole().equals(Role.TEACHER)) ? teacherInfoRepository.findByMemberIdAndStatus(writer.getId(), Status.ACTIVE)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.TEACHER_INFO_NOT_FOUND)) : null;
 
         int commentCount = commentRepository.countByPostIdAndStatus(post.getId(), Status.ACTIVE);


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #334 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

보스톡에서 티쳐가 게시물 작성할때 티쳐 프로필 조회가 null로 뜬 부분 해결
-> 작성자 정보를 조회한 게 아닌 로그인한 유저 정보를 조회한 거로 떴었음  

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
