### PR TITLE
🐛[FIX] 티처톡 자동채택 에러 해결

### DIFF
--- a/src/main/java/kr/co/teacherforboss/scheduler/QuestionScheduler.java
+++ b/src/main/java/kr/co/teacherforboss/scheduler/QuestionScheduler.java
@@ -54,6 +54,10 @@ public class QuestionScheduler {
     public void autoSelectAnswer(Question question) {
         Answer bestAnswer = answerRepository.findTopByQuestionIdAndSelectedAtIsNullAndStatusOrderByLikeCountDescDislikeCountAscCreatedAtAsc(question.getId(), Status.ACTIVE)
                 .orElseThrow(() -> new BoardHandler(ErrorStatus.ANSWER_NOT_FOUND));
-        boardCommandService.selectAnswer(question.getId(), bestAnswer.getId());
+
+        question.selectAnswer(bestAnswer);
+        TeacherSelectInfo teacherSelectInfo = teacherSelectInfoRepository.findByMemberIdAndStatus(bestAnswer.getMember().getId(), Status.ACTIVE)
+                .orElseThrow(() -> new BoardHandler(ErrorStatus.TEACHER_SELECT_INFO_NOT_FOUND));
+        teacherSelectInfo.increaseSelectCount();
     }
 }


### PR DESCRIPTION
## #️⃣ 이슈 번호

close #336 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

자동채택 에러 원인
1. dev 서버로 API 테스트하며 필드명 여러번 수정했었는데, 그러면서 과거에 작성했던 필드가 convert되지 않아 발생했었음 (ex. TaxData의 taxBookKeepingStatus로 저장되어야하는데 과거에 taxFillingStatus로 저장되어있어 변환 에러)
2. QuestionScheduler의 `autoSelectAnswer`의 경우 BoardCommandServiceImpl에 올라온 selectAnswer 메서드를 사용하는데 이거 쓰는 경우 유저 토큰 있어야 사용 가능함. 우선 민지가 수정하기 전 기존 코드로 수정해서 올림!

## 📝 예외 처리

> 이번 PR에서 작업한 Exception 처리 관련 내용을 자세히 적어주세요(생략 가능)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
